### PR TITLE
No-Jira: Fix null pointer exception during RosetteAPI construction.

### DIFF
--- a/api/src/main/java/com/basistech/rosette/api/RosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/RosetteAPI.java
@@ -80,6 +80,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.zip.GZIPInputStream;
 
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -124,7 +125,7 @@ public class RosetteAPI implements Closeable {
      * @throws IOException         General IO exception
      */
     public RosetteAPI(String key) throws IOException, RosetteAPIException {
-        this(key, null);
+        this(key, DEFAULT_URL_BASE);
     }
 
     /**
@@ -137,18 +138,17 @@ public class RosetteAPI implements Closeable {
      * @throws IOException         General IO exception
      */
     public RosetteAPI(String key, String alternateUrl) throws IOException, RosetteAPIException {
+        Objects.requireNonNull(alternateUrl, "alternateUrl cannot be null");
         urlBase = alternateUrl;
-        if (urlBase == null) {
-            checkVersionCompatibility();
-        } else {
-            if (urlBase.endsWith("/")) {
-                urlBase = urlBase.substring(0, urlBase.length() - 1);
-            }
+        if (urlBase.endsWith("/")) {
+            urlBase = urlBase.substring(0, urlBase.length() - 1);
         }
         this.key = key;
         this.failureRetries = 1;
         mapper = ApiModelMixinModule.setupObjectMapper(new ObjectMapper());
         httpClient = HttpClients.createDefault();
+
+        checkVersionCompatibility();
     }
 
     /**

--- a/api/src/test/java/com/basistech/rosette/api/AbstractTest.java
+++ b/api/src/test/java/com/basistech/rosette/api/AbstractTest.java
@@ -30,6 +30,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPOutputStream;
 
 public abstract class AbstractTest extends Assert {
+    public static final String INFO_REPONSE = "{ \"buildNumber\": \"6bafb29d\", \"buildTime\": \"2015.10.08_10:19:26\", \"name\": "
+            + "\"RosetteAPI\", \"version\": \"0.7.0\", \"versionChecked\": true }";
     protected static int serverPort;
     protected static ObjectMapper mapper;
 

--- a/api/src/test/java/com/basistech/rosette/api/InvalidErrorTest.java
+++ b/api/src/test/java/com/basistech/rosette/api/InvalidErrorTest.java
@@ -16,13 +16,11 @@
 
 package com.basistech.rosette.api;
 
-import com.basistech.util.LanguageCode;
 import org.junit.Test;
 import org.mockserver.client.server.MockServerClient;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
-import java.io.IOException;
 
 public class InvalidErrorTest extends AbstractTest {
 
@@ -36,10 +34,9 @@ public class InvalidErrorTest extends AbstractTest {
                                 .withStatusCode(404)
                 );
         String mockServiceUrl = "http://localhost:" + Integer.toString(serverPort) + "/rest//v1";
-        RosetteAPI api = new RosetteAPI("my-key-123", mockServiceUrl);
         boolean exceptional = false;
         try {
-            api.getCategories("Nothing to see here", LanguageCode.AFRIKAANS, null);
+            new RosetteAPI("my-key-123", mockServiceUrl);
         } catch (RosetteAPIException e) {
             exceptional = true;
             assertEquals("invalidErrorResponse", e.getCode());

--- a/api/src/test/java/com/basistech/rosette/api/RosetteAPITest.java
+++ b/api/src/test/java/com/basistech/rosette/api/RosetteAPITest.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockserver.client.server.MockServerClient;
+import org.mockserver.matchers.Times;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 
@@ -112,7 +113,10 @@ public class RosetteAPITest extends AbstractTest {
                                     .withBody("Invalid path; '//'")
                                     .withStatusCode(404)
                     );
-
+            mockServer.when(HttpRequest.request().withPath("^(?!//).+"), Times.exactly(1)).respond(HttpResponse.response()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody(INFO_REPONSE, StandardCharsets.UTF_8)
+                    .withStatusCode(200));
             if (responseStr.length() > 200) {  // test gzip if response is somewhat big
                 mockServer.when(HttpRequest.request().withPath("^(?!/info).+"))
                         .respond(HttpResponse.response()
@@ -131,7 +135,7 @@ public class RosetteAPITest extends AbstractTest {
                 .respond(HttpResponse.response()
                     .withStatusCode(200)
                     .withHeader("Content-Type", "application/json")
-                    .withBody("{ \"buildNumber\": \"6bafb29d\", \"buildTime\": \"2015.10.08_10:19:26\", \"name\": \"RosetteAPI\", \"version\": \"0.7.0\", \"versionChecked\": true }", StandardCharsets.UTF_8));
+                    .withBody(INFO_REPONSE, StandardCharsets.UTF_8));
 
             String mockServiceUrl = "http://localhost:" + Integer.toString(serverPort) + "/rest/v1";
             api = new RosetteAPI("my-key-123", mockServiceUrl);


### PR DESCRIPTION
The issue is that the constructor was using checkVersionCompatibility before it had initialized all the fields that said method depended on.
