### PR TITLE
release 1.2:

### DIFF
--- a/api/src/main/java/com/basistech/rosette/api/RosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/RosetteAPI.java
@@ -32,6 +32,7 @@ import com.basistech.rosette.apimodel.NameSimilarityRequest;
 import com.basistech.rosette.apimodel.NameSimilarityResponse;
 import com.basistech.rosette.apimodel.NameTranslationRequest;
 import com.basistech.rosette.apimodel.NameTranslationResponse;
+import com.basistech.rosette.apimodel.Options;
 import com.basistech.rosette.apimodel.PingResponse;
 import com.basistech.rosette.apimodel.RelationshipsOptions;
 import com.basistech.rosette.apimodel.RelationshipsResponse;
@@ -48,6 +49,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.io.ByteStreams;
+//import org.apache.commons.codec.language.bm.Lang;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -125,6 +127,10 @@ public class RosetteAPI implements Closeable {
     private String key;
     private String urlBase = DEFAULT_URL_BASE;
     private int failureRetries;
+    private LanguageCode language;
+    private Options options;
+    private String genre;
+    private DocumentRequest.Builder apiBuilder;
     private ObjectMapper mapper;
     private CloseableHttpClient httpClient;
     private List<Header> customHeaders;
@@ -160,11 +166,12 @@ public class RosetteAPI implements Closeable {
         mapper = ApiModelMixinModule.setupObjectMapper(new ObjectMapper());
         customHeaders = new ArrayList<>();
         initHttpClient();
-
+        apiBuilder = new DocumentRequest.Builder();
         checkVersionCompatibility();
     }
 
     /**
+     * Returns the version of the binding.
      *
      * @return version of the binding
      */
@@ -194,6 +201,74 @@ public class RosetteAPI implements Closeable {
      */
     public void setAPIKey(String key) {
         this.key = key;
+    }
+
+    /**
+     * Sets the language code.
+     *
+     * @param language LanguageCode passed by user
+     */
+    public void setLanguage(LanguageCode language) {
+        this.language = language;
+        apiBuilder.language(language);
+    }
+
+    /**
+     * Sets the language code.
+     *
+     * @param language String to be converted to LanguageCode
+     */
+    public void setLanguage(String language) {
+        this.language =  LanguageCode.ISO639IsValid(language) ? LanguageCode.lookupByISO639(language)
+                : LanguageCode.UNKNOWN;
+        apiBuilder.language(this.language);
+    }
+
+    /**
+     * Return language code.
+     *
+     * @return source language
+     */
+    public LanguageCode getLanguageCode() {
+        return language;
+    }
+
+    /**
+     * Sets the genre.
+     *
+     * @param genre genre (i.e. social-media)
+     */
+    public void setGenre(String genre) {
+        this.genre = genre;
+        apiBuilder.genre(genre);
+    }
+
+    /**
+     * Returns the genre.
+     *
+     * @return genre if being used by API
+     */
+    public String getGenre() {
+        return genre;
+    }
+
+    /**
+     * Sets the options for the specific search.
+     *
+     * @param o object of Options subclass for the particular search
+     */
+    public void setOptions(Options o) {
+        this.options = o;
+        apiBuilder.options(o);
+    }
+
+    /**
+     * Returns options used by API.
+     *
+     * @return options
+     */
+    public Options getOptions() {
+        return options;
     }
 
     /**
@@ -244,7 +319,7 @@ public class RosetteAPI implements Closeable {
     }
 
     /**
-     * Checks binding version compatiblity against the Rosette API server
+     * Checks binding version compatibility against the Rosette API server
      *
      * @return boolean true if compatible
      * @throws IOException
@@ -290,10 +365,27 @@ public class RosetteAPI implements Closeable {
      * @return the response.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getNameTranslation(String)
      */
+    @Deprecated
     public NameTranslationResponse getNameTranslation(NameTranslationRequest request)
             throws RosetteAPIException, IOException {
         return sendPostRequest(request, urlBase + NAME_TRANSLATION_SERVICE_PATH, NameTranslationResponse.class);
+    }
+
+    /**
+     * Translates a name into the target language specified by the API object.
+     *
+     * @param content Name to be translated.
+     *
+     * @return translated name
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public NameTranslationResponse getNameTranslation(String content) throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + NAME_TRANSLATION_SERVICE_PATH, NameTranslationResponse.class);
     }
 
     /**
@@ -306,13 +398,34 @@ public class RosetteAPI implements Closeable {
      * descending confidence.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated Replaced by getLanguage(InputStream, String)
      */
+    @Deprecated
     public LanguageResponse getLanguage(InputStream inputStream, String contentType, LanguageOptions options)
             throws RosetteAPIException, IOException {
         byte[] bytes = getBytes(inputStream);
         Request request = new DocumentRequest.Builder().contentBytes(bytes, contentType)
                 .options(options).build();
         return sendPostRequest(request, urlBase + LANGUAGE_SERVICE_PATH, LanguageResponse.class);
+    }
+
+    /**
+     * Performs language identification on data from an InputSteam. Builds request object from API, not parameters.
+     * Returns a list of languages.
+     *
+     * @param inputStream Input stream of file
+     * @param contentType the content type (e.g. text/html)
+     *
+     * @return An ordered list of detected languages, including language and detection confidence, sorted by
+     * descending confidence.
+     * @throws RosetteAPIException - There's a problem with the Rosette API request
+     * @throws IOException         - There's a problem with communication or JSON serialization/deserialization
+     */
+    public LanguageResponse getLanguage(InputStream inputStream, String contentType) throws RosetteAPIException, IOException {
+        byte[]  bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + LANGUAGE_SERVICE_PATH, LanguageResponse.class);
     }
 
     /**
@@ -324,13 +437,31 @@ public class RosetteAPI implements Closeable {
      * descending confidence.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated Replaced by getLanguage(URL)
      */
+    @Deprecated
     public LanguageResponse getLanguage(URL url, LanguageOptions options) throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
                 .contentUri(url.toString())
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + LANGUAGE_SERVICE_PATH, LanguageResponse.class);
+    }
+
+    /**
+     * Performs language identification on data read from an URL. Builds request object from API, not parameters.
+     * Returns a list of languages.
+     *
+     * @param url URL for language detection
+     * @return An ordered list of detected languages, including language and detection confidence, sorted by
+     * descending confidence.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public LanguageResponse getLanguage(URL url) throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + LANGUAGE_SERVICE_PATH, LanguageResponse.class);
     }
 
     /**
@@ -342,12 +473,31 @@ public class RosetteAPI implements Closeable {
      * descending confidence.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated Replaced by getLanguage(String)
      */
+    @Deprecated
     public LanguageResponse getLanguage(String content, LanguageOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder().content(content)
                 .options(options).build();
         return sendPostRequest(request, urlBase + LANGUAGE_SERVICE_PATH, LanguageResponse.class);
+    }
+
+    /**
+     * Performs language identification on data read from a string. Builds request object from API not parameters.
+     * Returns a list of languages.
+     *
+     * @param content String content for language detection.
+     *
+     * @return An ordered list of detected languages, including language and detection confidence, sorted by
+     * descending confidence.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public LanguageResponse getLanguage(String content) throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + LANGUAGE_SERVICE_PATH, LanguageResponse.class);
     }
 
     /**
@@ -363,7 +513,10 @@ public class RosetteAPI implements Closeable {
      * @return MorphologyResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getMorphology(inputStream, contentType, MorphologicalFeature)
      */
+    @Deprecated
     public MorphologyResponse getMorphology(MorphologicalFeature morphologicalFeature,
                                             InputStream inputStream,
                                             String contentType,
@@ -380,6 +533,27 @@ public class RosetteAPI implements Closeable {
     }
 
     /**
+     * Returns morphological analysis of the input file. The response may include lemmas, part of speech tags,
+     * compound word components, and Han readings. Builds request object from API rather than from parameters.
+     * Support for specific return types depends on language.
+     *
+     * @param inputStream Input stream of file
+     * @param contentType The content type (e.g. text/html)
+     * @return MorphologyResponse
+     * @throws RosetteAPIException
+     * @throws IOException
+     */
+    public MorphologyResponse getMorphology(MorphologicalFeature morphologicalFeature,
+                                            InputStream inputStream,
+                                            String contentType)
+            throws RosetteAPIException, IOException {
+        byte[] bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + MORPHOLOGY_SERVICE_PATH + "/" + morphologicalFeature.toString(),
+                MorphologyResponse.class);
+    }
+
+    /**
      * Returns morphological analysis of the URL content.
      * The response may include lemmas, part of speech tags, compound word components, and Han readings.
      * Support for specific return types depends on language.
@@ -391,7 +565,10 @@ public class RosetteAPI implements Closeable {
      * @return MorphologyResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getMorphology(URL, MorphologicalFeature)
      */
+    @Deprecated
     public MorphologyResponse getMorphology(MorphologicalFeature morphologicalFeature, URL url,
                                             LanguageCode language,
                                             MorphologyOptions options) throws RosetteAPIException, IOException {
@@ -401,6 +578,23 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + MORPHOLOGY_SERVICE_PATH + "/" + morphologicalFeature.toString(),
+                MorphologyResponse.class);
+    }
+
+    /**
+     * Returns morphological analysis of the URL content. The response may include lemmas, part of speech tags, compound
+     * word components, and Han readings. Builds request object from API, rather than from parameters. Support for
+     * specific return types depends on language.
+     *
+     * @param url URL containing the data
+     * @return MorphologyResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a problem with communication or JSON serialization/deserialization.
+     */
+    public MorphologyResponse getMorphology(MorphologicalFeature morphologicalFeature, URL url)
+            throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + MORPHOLOGY_SERVICE_PATH + "/" + morphologicalFeature.toString(),
                 MorphologyResponse.class);
     }
 
@@ -416,7 +610,10 @@ public class RosetteAPI implements Closeable {
      * @return MorphologyResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getMorphology(String, MorphologicalFeature)
      */
+    @Deprecated
     public MorphologyResponse getMorphology(MorphologicalFeature morphologicalFeature, String content,
                                             LanguageCode language, MorphologyOptions options)
             throws RosetteAPIException, IOException {
@@ -426,9 +623,26 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + MORPHOLOGY_SERVICE_PATH + "/" + morphologicalFeature.toString(),
-
                 MorphologyResponse.class);
     }
+
+    /**
+     * Returns morphological analysis of a string. The response may include lemmas, part of speech tags, compound word
+     * components, and Han reading. Constructs request object from API information rather than from parameters. Support
+     * for specific return types depends on language.
+     *
+     * @param content String containing the data.
+     * @return MorphologyResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public MorphologyResponse getMorphology(MorphologicalFeature morphologicalFeature, String content)
+            throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + MORPHOLOGY_SERVICE_PATH + "/" + morphologicalFeature.toString(),
+                MorphologyResponse.class);
+    }
+
 
     /**
      * Returns entities extracted from the input file.
@@ -446,7 +660,10 @@ public class RosetteAPI implements Closeable {
      * @return EntitiesResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaces by getEntities(InputStream, String)
      */
+    @Deprecated
     public EntitiesResponse getEntities(InputStream inputStream,
                                         String contentType,
                                         LanguageCode language, EntitiesOptions options)
@@ -459,6 +676,28 @@ public class RosetteAPI implements Closeable {
                 .build();
         return sendPostRequest(request, urlBase + ENTITIES_SERVICE_PATH, EntitiesResponse.class);
     }
+
+    /**
+     * Returns entities extracted from the input file. Builds request object from API fields not from parameters.
+     * <p>
+     * The response is a list of extracted entities. Each entity includes chain ID (all instances of the same
+     * entity share a chain id), mention (entity text in the input), normalized text (the most complete form
+     * of this entity that appears in the input), count (how many times this entity appears in the input), and the
+     * confidence associated with the extraction.
+     *
+     * @param inputStream Input stream of file.
+     * @param contentType The content type of the data (e.g. text/html)
+     * @return EntitiesResponse
+     * @throws RosetteAPIException
+     * @throws IOException
+     */
+    public EntitiesResponse getEntities(InputStream inputStream, String contentType)
+            throws RosetteAPIException, IOException {
+        byte[] bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + ENTITIES_SERVICE_PATH, EntitiesResponse.class);
+    }
+
 
     /**
      * Returns entities extracted from the URL content.
@@ -475,7 +714,10 @@ public class RosetteAPI implements Closeable {
      * @return EntitiesResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getEntities(URL)
      */
+    @Deprecated
     public EntitiesResponse getEntities(URL url, LanguageCode language, EntitiesOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -484,6 +726,26 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + ENTITIES_SERVICE_PATH, EntitiesResponse.class);
+    }
+
+    /**
+     *Returns entities extracted from the URL content. Request object built through API rather than parameters.
+     * <p>
+     * The response is a list of extracted entities.
+     * Each entity includes chain ID (all instances of the same entity share a chain id),
+     * mention (entity text in the input), normalized text (the most complete form of this entity that appears in
+     * the input), count (how many times this entity appears in the input), and the confidence associated with the
+     * extraction.
+     *
+     * @param url URL containing the data.
+     * @return EntitiesResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public EntitiesResponse getEntities(URL url)
+            throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + ENTITIES_SERVICE_PATH, EntitiesResponse.class);
     }
 
     /**
@@ -501,7 +763,10 @@ public class RosetteAPI implements Closeable {
      * @return EntitiesResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getEntities(String)
      */
+    @Deprecated
     public EntitiesResponse getEntities(String content, LanguageCode language, EntitiesOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -510,6 +775,26 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + ENTITIES_SERVICE_PATH, EntitiesResponse.class);
+    }
+
+    /**
+     *Returns entities extracted from a string. Request object built from API rather than from parameters.
+     * <p>
+     * The response is a list of extracted entities.
+     * Each entity includes chain ID (all instances of the same entity share a chain id),
+     * mention (entity text in the input), normalized text (the most complete form of this entity that appears in
+     * the input), count (how many times this entity appears in the input), and the confidence associated with the
+     * extraction.
+     *
+     * @param content String containing the data.
+     * @return EntitiesResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public EntitiesResponse getEntities(String content)
+            throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + ENTITIES_SERVICE_PATH, EntitiesResponse.class);
     }
 
     /**
@@ -597,10 +882,13 @@ public class RosetteAPI implements Closeable {
      * @return CategoriesResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getCategories(InputStream, String)
      */
+    @Deprecated
     public CategoriesResponse getCategories(InputStream inputStream,
-                                            String contentType,
-                                            LanguageCode language, CategoriesOptions options)
+                                                 String contentType,
+                                                 LanguageCode language, CategoriesOptions options)
             throws RosetteAPIException, IOException {
         byte[] bytes = getBytes(inputStream);
         Request request = new DocumentRequest.Builder()
@@ -609,6 +897,26 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + CATEGORIES_SERVICE_PATH, CategoriesResponse.class);
+    }
+
+    /**
+     * Returns an ordered list of categories identified in the input file. The categories are Tier 1 contextual
+     * categories defined in the <a href="http://www.iab.net/QAGInitiative/overview/taxonomy">QAG Taxonomy</a>.
+     * The request object is built from the API object rather than from the parameters.
+     * <p>
+     * The response is the contextual categories identified in the input.
+     * @param inputStream Input stream of file.
+     * @param contentType The contentType of the file (e.g. text/html)
+     * @return CategoriesResponse
+     * @throws RosetteAPIException
+     * @throws IOException
+     */
+    public CategoriesResponse getCategories(InputStream inputStream,
+                                            String contentType)
+            throws RosetteAPIException, IOException {
+        byte[] bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + CATEGORIES_SERVICE_PATH, CategoriesResponse.class);
     }
 
     /**
@@ -623,7 +931,10 @@ public class RosetteAPI implements Closeable {
      * @return CategoriesResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated Replaced by getCategories(URL)
      */
+    @Deprecated
     public CategoriesResponse getCategories(URL url, LanguageCode language, CategoriesOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -632,6 +943,24 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + CATEGORIES_SERVICE_PATH, CategoriesResponse.class);
+    }
+
+    /**
+     * Returns an ordered list of categories identified in the input file. The categories are Tier 1 contextual
+     * categories defined in the <a href="http://www.iab.net/QAGInitiative/overview/taxonomy">QAG Taxonomy</a>.
+     * The request object is built from the API object rather than from the parameters.
+     * <p>
+     * The response is the contextual categories identified in the input.
+     *
+     * @param url URL containing the data.
+     * @return CategoriesResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public CategoriesResponse getCategories(URL url)
+            throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + CATEGORIES_SERVICE_PATH, CategoriesResponse.class);
     }
 
     /**
@@ -646,7 +975,10 @@ public class RosetteAPI implements Closeable {
      * @return CategoriesResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getCategories(String)
      */
+    @Deprecated
     public CategoriesResponse getCategories(String content, LanguageCode language, CategoriesOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -655,6 +987,24 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + CATEGORIES_SERVICE_PATH, CategoriesResponse.class);
+    }
+
+    /**
+     * Returns an ordered list of categories identified in the input file. The categories are Tier 1 contextual
+     * categories defined in the <a href="http://www.iab.net/QAGInitiative/overview/taxonomy">QAG Taxonomy</a>.
+     * The request object is built from the API object rather than from the parameters.
+     * <p>
+     * The response is the contextual categories identified in the input.
+     *
+     * @param content String containing the data.
+     * @return CategoriesResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a problem with communication or JSON serialization/deserialization.
+     */
+    public CategoriesResponse getCategories(String content)
+            throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + CATEGORIES_SERVICE_PATH, CategoriesResponse.class);
     }
 
     /**
@@ -676,8 +1026,11 @@ public class RosetteAPI implements Closeable {
      * @param options  RelationshipOptions
      * @return RelationshipsResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request
-     * @throws IOException         - If there is a commuincation or JSON serialization/deserialization error
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getRelationships(String)
      */
+    @Deprecated
     public RelationshipsResponse getRelationships(String content, LanguageCode language, RelationshipsOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -686,6 +1039,31 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + RELATIONSHIPS_SERVICE_PATH, RelationshipsResponse.class);
+    }
+
+    /**
+     *
+     * Returns each relationship extracted from the input. Request object uses API attributes rather than parameters.
+     * <p>
+     * The response is a list of extracted relationships. A relationship contains
+     * <p>
+     * predicate - usually the main verb, property or action that is expressed by the text
+     * arg1 - usually the subject, agent or main actor of the relationship
+     * arg2 [optional] - complements the predicate and is usually the object, theme or patient of the relationship
+     * arg3 [optional] - usually an additional object in ditransitive verbs
+     * adjuncts [optional] - contain all optional parts of a relationship which are not temporal or locative expressions
+     * locatives [optional] - usually express the locations the action expressed by the relationship took place
+     * temporals [ optional] - usually express the time in which the action expressed by the relationship took place
+     * confidence - a measure of quality of relationship extraction, between 0 - 1
+     * @param content String containing the data.
+     * @return RelationshipsResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public RelationshipsResponse getRelationships(String content)
+            throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + RELATIONSHIPS_SERVICE_PATH, RelationshipsResponse.class);
     }
 
     /**
@@ -709,7 +1087,10 @@ public class RosetteAPI implements Closeable {
      * @return RelationshipsResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error
+     *
+     * @deprecated Replaced by getRelationships(InputStream, String)
      */
+    @Deprecated
     public RelationshipsResponse getRelationships(InputStream inputStream,
                                                   String contentType,
                                                   LanguageCode language, RelationshipsOptions options)
@@ -721,6 +1102,33 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + RELATIONSHIPS_SERVICE_PATH, RelationshipsResponse.class);
+    }
+
+    /**
+     * Returns each relationship extracted from the input. Request object uses API attributes rather than parameters.
+     * <p>
+     * The response is a list of extracted relationships. A relationship contains
+     * <p>
+     * predicate - usually the main verb, property or action that is expressed by the text
+     * arg1 - usually the subject, agent or main actor of the relationship
+     * arg2 [optional] - complements the predicate and is usually the object, theme or patient of the relationship
+     * arg3 [optional] - usually an additional object in ditransitive verbs
+     * adjuncts [optional] - contain all optional parts of a relationship which are not temporal or locative expressions
+     * locatives [optional] - usually express the locations the action expressed by the relationship took place
+     * temporals [ optional] - usually express the time in which the action expressed by the relationship took place
+     * confidence - a measure of quality of relationship extraction, between 0 - 1
+     * @param inputStream Input stream of file.
+     * @param contentType The content type of the file.
+     * @return RelationshipsResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public RelationshipsResponse getRelationships(InputStream inputStream,
+                                                  String contentType)
+            throws RosetteAPIException, IOException {
+        byte[] bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + RELATIONSHIPS_SERVICE_PATH, RelationshipsResponse.class);
     }
 
     /**
@@ -742,8 +1150,11 @@ public class RosetteAPI implements Closeable {
      * @param options  RelationshipOptions
      * @return RelationshipsResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request
-     * @throws IOException         - If there is a commuincation or JSON serialization/deserialization error
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error
+     *
+     * @deprecated replaced getRelationships(URL)
      */
+    @Deprecated
     public RelationshipsResponse getRelationships(URL url, LanguageCode language, RelationshipsOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -752,6 +1163,31 @@ public class RosetteAPI implements Closeable {
                 .options(options)
                 .build();
         return sendPostRequest(request, urlBase + RELATIONSHIPS_SERVICE_PATH, RelationshipsResponse.class);
+    }
+
+    /**
+     * Returns each relationship extracted from the input.
+     * <p>
+     * The response is a list of extracted relationships. A relationship contains
+     * <p>
+     * predicate - usually the main verb, property or action that is expressed by the text
+     * arg1 - usually the subject, agent or main actor of the relationship
+     * arg2 [optional] - complements the predicate and is usually the object, theme or patient of the relationship
+     * arg3 [optional] - usually an additional object in ditransitive verbs
+     * adjuncts [optional] - contain all optional parts of a relationship which are not temporal or locative expressions
+     * locatives [optional] - usually express the locations the action expressed by the relationship took place
+     * temporals [ optional] - usually express the time in which the action expressed by the relationship took place
+     * confidence - a measure of quality of relationship extraction, between 0 - 1
+     *
+     * @param url URL containing the data.
+     * @return RelationshipOptions
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a problem with communication or JSON serialization/deserialization.
+     */
+    public RelationshipsResponse getRelationships(URL url)
+            throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + RELATIONSHIPS_SERVICE_PATH, RelationshipsResponse.class);
     }
 
     /**
@@ -766,7 +1202,10 @@ public class RosetteAPI implements Closeable {
      * @return SentimentResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getSentiment(InputStream, String)
      */
+    @Deprecated
     public SentimentResponse getSentiment(InputStream inputStream,
                                           String contentType,
                                           LanguageCode language, SentimentOptions options)
@@ -781,6 +1220,26 @@ public class RosetteAPI implements Closeable {
     }
 
     /**
+     * Analyzes the positive and negative sentiment expressed by the input. Request object built from API rather than
+     * from individual request.
+     * <p>
+     * The response contains sentiment analysis results.
+     *
+     * @param inputStream Input stream of file.
+     * @param contentType The content type of the file (e.g. text/html)
+     * @return SentimentResponse
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public SentimentResponse getSentiment(InputStream inputStream,
+                                          String contentType)
+            throws RosetteAPIException, IOException {
+        byte[] bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + SENTIMENT_SERVICE_PATH, SentimentResponse.class);
+    }
+
+    /**
      * Analyzes the positive and negative sentiment expressed by the input.
      * <p>
      * The response contains sentiment analysis results.
@@ -791,7 +1250,10 @@ public class RosetteAPI implements Closeable {
      * @return SentimentResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getSentiment(URL)
      */
+    @Deprecated
     public SentimentResponse getSentiment(URL url, LanguageCode language, SentimentOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -803,6 +1265,23 @@ public class RosetteAPI implements Closeable {
     }
 
     /**
+     * Analyzes the positive and negative sentiment expressed by the input. Request object built from API rather than
+     * from individual request.
+     * <p>
+     * The response contains sentiment analysis results.
+     *
+     * @param url URL containing the data.
+     * @return SentimentOptions
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public SentimentResponse getSentiment(URL url)
+            throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + SENTIMENT_SERVICE_PATH, SentimentResponse.class);
+    }
+
+    /**
      * Analyzes the positive and negative sentiment expressed by the input.
      * <p>
      * The response contains sentiment analysis results.
@@ -813,7 +1292,10 @@ public class RosetteAPI implements Closeable {
      * @return SentimentResponse
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getSentiment(String)
      */
+    @Deprecated
     public SentimentResponse getSentiment(String content, LanguageCode language, SentimentOptions options)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -825,6 +1307,23 @@ public class RosetteAPI implements Closeable {
     }
 
     /**
+     * Analyzes the positive and negative sentiment expressed by the input. Request object uses API object rather than
+     * parameters.
+     * <p>
+     * The response contains sentiment analysis results.
+     *
+     * @param content String containing the data.
+     * @return SentimentOptions
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public SentimentResponse getSentiment(String content)
+            throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + SENTIMENT_SERVICE_PATH, SentimentResponse.class);
+    }
+
+    /**
      * Divides the input into tokens.
      *
      * @param inputStream Input stream of file.
@@ -833,7 +1332,10 @@ public class RosetteAPI implements Closeable {
      * @return The response contains a list of tokens.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getTokens(InputStream, String)
      */
+    @Deprecated
     public TokensResponse getTokens(InputStream inputStream, String contentType, LanguageCode language)
             throws RosetteAPIException, IOException {
         byte[] bytes = getBytes(inputStream);
@@ -845,6 +1347,23 @@ public class RosetteAPI implements Closeable {
     }
 
     /**
+     * Divides the input into tokens. Request object built through API calls rather than from parameters.
+     *
+     * @param inputStream Input stream of file.
+     * @param contentType The content type of the file (e.g. text/html)
+     *
+     * @return The response contains a list of tokens.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a problem with communication or JSON serialization/deserialization
+     */
+    public TokensResponse getTokens(InputStream inputStream, String contentType)
+            throws RosetteAPIException, IOException {
+        byte[] bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + TOKENS_SERVICE_PATH, TokensResponse.class);
+    }
+
+    /**
      * Divides the input into tokens.
      *
      * @param url      URL containing the data.
@@ -852,13 +1371,29 @@ public class RosetteAPI implements Closeable {
      * @return The response contains a list of tokens.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getTokens(URL)
      */
+    @Deprecated
     public TokensResponse getTokens(URL url, LanguageCode language) throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
                 .language(language)
                 .contentUri(url.toString())
                 .build();
         return sendPostRequest(request, urlBase + TOKENS_SERVICE_PATH, TokensResponse.class);
+    }
+
+    /**
+     * Divides the input into tokens. Request object uses API fields rather than call parameters.
+     *
+     * @param url URL containing the data.
+     * @return The response contains a list of tokens.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public TokensResponse getTokens(URL url) throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + TOKENS_SERVICE_PATH, TokensResponse.class);
     }
 
     /**
@@ -869,13 +1404,29 @@ public class RosetteAPI implements Closeable {
      * @return The response contains a list of tokens.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getTokens(String)
      */
+    @Deprecated
     public TokensResponse getTokens(String content, LanguageCode language) throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
                 .language(language)
                 .content(content)
                 .build();
         return sendPostRequest(request, urlBase + TOKENS_SERVICE_PATH, TokensResponse.class);
+    }
+
+    /**
+     * Divides the input into tokens. Request object is built from the API object rather than from parameters.
+     *
+     * @param content String containing the data.
+     * @return The response contains a list of tokens.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public TokensResponse getTokens(String content) throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + TOKENS_SERVICE_PATH, TokensResponse.class);
     }
 
     /**
@@ -887,7 +1438,10 @@ public class RosetteAPI implements Closeable {
      * @return The response contains a list of sentences.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getSentences(InputStream, String)
      */
+    @Deprecated
     public SentencesResponse getSentences(InputStream inputStream,
                                           String contentType,
                                           LanguageCode language)
@@ -901,6 +1455,23 @@ public class RosetteAPI implements Closeable {
     }
 
     /**
+     * Divides the input into sentences. Request object is built from the API object rather than from parameters.
+     *
+     * @param inputStream Input stream of file.
+     * @param contentType The content type of the file (e.g. text/html).
+     * @return The response contains a list of sentences.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a problem with communication or JSON serialization/deserialization.
+     */
+    public SentencesResponse getSentences(InputStream inputStream,
+                                          String contentType)
+            throws RosetteAPIException, IOException {
+        byte[] bytes = getBytes(inputStream);
+        apiBuilder.contentBytes(bytes, contentType);
+        return sendPostRequest(apiBuilder.build(), urlBase + SENTENCES_SERVICE_PATH, SentencesResponse.class);
+    }
+
+    /**
      * Divides the input into sentences.
      *
      * @param url      URL containing the data.
@@ -908,13 +1479,29 @@ public class RosetteAPI implements Closeable {
      * @return The response contains a list of sentences.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getSentences(URL)
      */
+    @Deprecated
     public SentencesResponse getSentences(URL url, LanguageCode language) throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
                 .language(language)
                 .contentUri(url.toString())
                 .build();
         return sendPostRequest(request, urlBase + SENTENCES_SERVICE_PATH, SentencesResponse.class);
+    }
+
+    /**
+     * Divides the input into sentences. Request object is built from the API object rather than from parameters.
+     *
+     * @param url URL containing the data.
+     * @return The response contains a list of sentences.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication of JSON serialization/deserialization error.
+     */
+    public SentencesResponse getSentences(URL url) throws RosetteAPIException, IOException {
+        apiBuilder.contentUri(url.toString());
+        return sendPostRequest(apiBuilder.build(), urlBase + SENTENCES_SERVICE_PATH, SentencesResponse.class);
     }
 
     /**
@@ -925,7 +1512,10 @@ public class RosetteAPI implements Closeable {
      * @return The response contains a list of sentences.
      * @throws RosetteAPIException - If there is a problem with the Rosette API request.
      * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     *
+     * @deprecated replaced by getSentences(String)
      */
+    @Deprecated
     public SentencesResponse getSentences(String content, LanguageCode language)
             throws RosetteAPIException, IOException {
         Request request = new DocumentRequest.Builder()
@@ -933,6 +1523,20 @@ public class RosetteAPI implements Closeable {
                 .content(content)
                 .build();
         return sendPostRequest(request, urlBase + SENTENCES_SERVICE_PATH, SentencesResponse.class);
+    }
+
+    /**
+     * Divides the input into sentences. Request object is built from the API object rather than from parameters.
+     *
+     * @param content String containing the data.
+     * @return The response contains a list of sentences.
+     * @throws RosetteAPIException - If there is a problem with the Rosette API request.
+     * @throws IOException         - If there is a communication or JSON serialization/deserialization error.
+     */
+    public SentencesResponse getSentences(String content)
+            throws RosetteAPIException, IOException {
+        apiBuilder.content(content);
+        return sendPostRequest(apiBuilder.build(), urlBase + SENTENCES_SERVICE_PATH, SentencesResponse.class);
     }
 
     /**

--- a/api/src/test/java/com/basistech/rosette/api/RosetteAPITest.java
+++ b/api/src/test/java/com/basistech/rosette/api/RosetteAPITest.java
@@ -16,20 +16,7 @@
 
 package com.basistech.rosette.api;
 
-import com.basistech.rosette.apimodel.CategoriesResponse;
-import com.basistech.rosette.apimodel.DocumentRequest;
-import com.basistech.rosette.apimodel.EntitiesResponse;
-import com.basistech.rosette.apimodel.ErrorResponse;
-import com.basistech.rosette.apimodel.LanguageResponse;
-import com.basistech.rosette.apimodel.LinkedEntitiesResponse;
-import com.basistech.rosette.apimodel.MorphologyResponse;
-import com.basistech.rosette.apimodel.NameSimilarityRequest;
-import com.basistech.rosette.apimodel.NameSimilarityResponse;
-import com.basistech.rosette.apimodel.NameTranslationRequest;
-import com.basistech.rosette.apimodel.NameTranslationResponse;
-import com.basistech.rosette.apimodel.RelationshipsResponse;
-import com.basistech.rosette.apimodel.Request;
-import com.basistech.rosette.apimodel.SentimentResponse;
+import com.basistech.rosette.apimodel.*;
 import com.basistech.util.LanguageCode;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -196,7 +183,9 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            LanguageResponse response = api.getLanguage(request.getContent(), null);
+            //LanguageResponse response = api.getLanguage(request.getContent(), null);
+            api.setOptions(null);
+            LanguageResponse response = api.getLanguage(request.getContent());
             verifyLanguage(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -210,7 +199,9 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            LanguageResponse response = api.getLanguage(new URL(request.getContentUri()), null);
+            //LanguageResponse response = api.getLanguage(new URL(request.getContentUri()), null);
+            api.setOptions(null);
+            LanguageResponse response = api.getLanguage(new URL(request.getContentUri()));
             verifyLanguage(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -224,8 +215,11 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            MorphologyResponse response = api.getMorphology(MorphologicalFeature.COMPLETE,
-                    request.getContent(), null, null);
+            //MorphologyResponse response = api.getMorphology(MorphologicalFeature.COMPLETE,
+            //        request.getContent(), null, null);
+            api.setOptions(null);
+            api.setLanguage(null+"");
+            MorphologyResponse response = api.getMorphology(MorphologicalFeature.COMPLETE, request.getContent());
             verifyMorphology(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -244,8 +238,11 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            MorphologyResponse response = api.getMorphology(MorphologicalFeature.COMPLETE,
-                    new URL(request.getContentUri()), null, null);
+            api.setOptions(null);
+            api.setLanguage(null+"");
+            //MorphologyResponse response = api.getMorphology(MorphologicalFeature.COMPLETE,
+            //        new URL(request.getContentUri()), null, null);
+            MorphologyResponse response = api.getMorphology(MorphologicalFeature.COMPLETE, new URL(request.getContentUri()));
             verifyMorphology(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -259,7 +256,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            EntitiesResponse response = api.getEntities(request.getContent(), null, null);
+            api.setLanguage(null+"");
+            api.setOptions(null);
+            //EntitiesResponse response = api.getEntities(request.getContent(), null, null);
+            EntitiesResponse response = api.getEntities(request.getContent());
             verifyEntity(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -278,7 +278,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            EntitiesResponse response = api.getEntities(new URL(request.getContentUri()), null, null);
+            //EntitiesResponse response = api.getEntities(new URL(request.getContentUri()), null, null);
+            api.setLanguage(null+"");
+            api.setOptions(null);
+            EntitiesResponse response = api.getEntities(new URL(request.getContentUri()));
             verifyEntity(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -325,7 +328,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            CategoriesResponse response = api.getCategories(request.getContent(), null, null);
+            //CategoriesResponse response = api.getCategories(request.getContent(), null, null);
+            api.setLanguage(null+"");
+            api.setOptions(null);
+            CategoriesResponse response = api.getCategories(request.getContent());
             verifyCategory(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -345,7 +351,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            CategoriesResponse response = api.getCategories(new URL(request.getContentUri()), null, null);
+            api.setLanguage(null+"");
+            api.setOptions(null);
+            CategoriesResponse response = api.getCategories(new URL(request.getContentUri()));
+            //CategoriesResponse response = api.getCategories(new URL(request.getContentUri()), null, null);
             verifyCategory(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -359,7 +368,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            RelationshipsResponse response = api.getRelationships(request.getContent(), language, null);
+            api.setLanguage(language);
+            api.setOptions(null);
+            RelationshipsResponse response = api.getRelationships(request.getContent());
+            //RelationshipsResponse response = api.getRelationships(request.getContent(), language, null);
             verifyRelationships(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -378,7 +390,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            RelationshipsResponse response = api.getRelationships(new URL(request.getContentUri()), language, null);
+            api.setLanguage(language);
+            api.setOptions(null);
+            RelationshipsResponse response = api.getRelationships(new URL(request.getContentUri()));
+            //RelationshipsResponse response = api.getRelationships(new URL(request.getContentUri()), language, null);
             verifyRelationships(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -392,7 +407,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            SentimentResponse response = api.getSentiment(request.getContent(), language, null);
+            api.setOptions(null);
+            api.setLanguage(language);
+            SentimentResponse response = api.getSentiment(request.getContent());
+            //SentimentResponse response = api.getSentiment(request.getContent(), language, null);
             verifySentiment(response);
         } catch (RosetteAPIException e) {
             verifyException(e);
@@ -413,7 +431,10 @@ public class RosetteAPITest extends AbstractTest {
         }
         DocumentRequest<?> request = readValue(DocumentRequest.class);
         try {
-            SentimentResponse response = api.getSentiment(new URL(request.getContentUri()), language, null);
+            api.setLanguage(language);
+            api.setOptions(null);
+            SentimentResponse response = api.getSentiment(new URL(request.getContentUri()));
+            //SentimentResponse response = api.getSentiment(new URL(request.getContentUri()), language, null);
             verifySentiment(response);
         } catch (RosetteAPIException e) {
             verifyException(e);

--- a/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
@@ -40,7 +40,9 @@ public final class CategoriesExample extends ExampleBase {
     private void run() throws IOException, RosetteAPIException {
         String categoriesUrlData = "http://www.onlocationvacations.com/2015/03/05/the-new-ghostbusters-movie-begins-filming-in-boston-in-june/";
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        CategoriesResponse response = rosetteApi.getCategories(categoriesUrlData, null, null);
+        rosetteApi.setLanguage(null + "");
+        rosetteApi.setOptions(null);
+        CategoriesResponse response = rosetteApi.getCategories(categoriesUrlData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
@@ -37,7 +37,9 @@ public final class EntitiesExample extends ExampleBase {
         String entitiesTextData = "Bill Murray will appear in new Ghostbusters film: Dr. Peter Venkman was spotted filming a cameo in Boston this… http://dlvr.it/BnsFfS";
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        EntitiesResponse response = rosetteApi.getEntities(entitiesTextData, null, null);
+        rosetteApi.setLanguage(null + "");
+        rosetteApi.setOptions(null);
+        EntitiesResponse response = rosetteApi.getEntities(entitiesTextData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
@@ -38,7 +38,8 @@ public final class LanguageExample extends ExampleBase {
         String languageData = "Por favor Señorita, says the man.";
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        LanguageResponse response = rosetteApi.getLanguage(languageData, null);
+        rosetteApi.setOptions(null);
+        LanguageResponse response = rosetteApi.getLanguage(languageData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
@@ -39,8 +39,10 @@ public final class MorphologyCompleteExample extends ExampleBase {
         String morphologyCompleteData = "The quick brown fox jumped over the lazy dog. Yes he did.";
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
+        rosetteApi.setOptions(null);
+        rosetteApi.setLanguage(null + "");
         MorphologyResponse response = rosetteApi.getMorphology(MorphologicalFeature.COMPLETE,
-                morphologyCompleteData, null, null);
+                morphologyCompleteData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
@@ -39,8 +39,10 @@ public final class MorphologyCompoundComponentsExample extends ExampleBase {
         String morphologyCompoundComponentsData = "Rechtsschutzversicherungsgesellschaften";
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
+        rosetteApi.setLanguage(null + "");
+        rosetteApi.setOptions(null);
         MorphologyResponse response = rosetteApi.getMorphology(MorphologicalFeature.COMPOUND_COMPONENTS,
-                morphologyCompoundComponentsData, null, null);
+                morphologyCompoundComponentsData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
@@ -40,7 +40,7 @@ public final class MorphologyHanReadingsExample extends ExampleBase {
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
         MorphologyResponse response = rosetteApi.getMorphology(MorphologicalFeature.HAN_READINGS,
-                morphologyHanReadingsData, null, null);
+                morphologyHanReadingsData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
@@ -40,7 +40,7 @@ public final class MorphologyLemmasExample extends ExampleBase {
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
         MorphologyResponse response = rosetteApi.getMorphology(MorphologicalFeature.LEMMAS,
-                morphologyLemmasData, null, null);
+                morphologyLemmasData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
@@ -40,7 +40,7 @@ public final class MorphologyPartsOfSpeechExample extends ExampleBase {
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
         MorphologyResponse response = rosetteApi.getMorphology(MorphologicalFeature.PARTS_OF_SPEECH,
-                morphologyPartsOfSpeechData, null, null);
+                morphologyPartsOfSpeechData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
@@ -42,7 +42,8 @@ public final class NameTranslationExample extends ExampleBase {
                 .build();
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        NameTranslationResponse response = rosetteApi.getNameTranslation(request);
+        rosetteApi.setLanguage(LanguageCode.ENGLISH);
+        NameTranslationResponse response = rosetteApi.getNameTranslation(translatedNameData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
@@ -17,7 +17,7 @@ package com.basistech.rosette.examples;
 
 import com.basistech.rosette.api.RosetteAPI;
 import com.basistech.rosette.api.RosetteAPIException;
-import com.basistech.rosette.apimodel.NameTranslationRequest;
+//import com.basistech.rosette.apimodel.NameTranslationRequest;
 import com.basistech.rosette.apimodel.NameTranslationResponse;
 import com.basistech.util.LanguageCode;
 

--- a/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
@@ -38,8 +38,8 @@ public final class NameTranslationExample extends ExampleBase {
 
     private void run() throws IOException, RosetteAPIException {
         String translatedNameData = "معمر محمد أبو منيار القذاف";
-        NameTranslationRequest request = new NameTranslationRequest.Builder(translatedNameData, LanguageCode.ENGLISH)
-                .build();
+        //NameTranslationRequest request = new NameTranslationRequest.Builder(translatedNameData, LanguageCode.ENGLISH)
+        //.build();
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
         rosetteApi.setLanguage(LanguageCode.ENGLISH);

--- a/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
@@ -38,7 +38,7 @@ public final class RelationshipsExample extends ExampleBase {
         String relationshipsTextData = "The Ghostbusters movie was filmed in Boston.";
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        RelationshipsResponse response = rosetteApi.getRelationships(relationshipsTextData, null, null);
+        RelationshipsResponse response = rosetteApi.getRelationships(relationshipsTextData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
@@ -38,7 +38,7 @@ public final class SentencesExample extends ExampleBase {
         String sentencesData = "This land is your land. This land is my land\nFrom California to the New York island;\nFrom the red wood forest to the Gulf Stream waters\n\nThis land was made for you and Me.\n\nAs I was walking that ribbon of highway,\nI saw above me that endless skyway:\nI saw below me that golden valley:\nThis land was made for you and me.";
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        SentencesResponse response = rosetteApi.getSentences(sentencesData, null);
+        SentencesResponse response = rosetteApi.getSentences(sentencesData);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
@@ -46,7 +46,7 @@ public final class SentimentExample extends ExampleBase {
         FileInputStream inputStream = new FileInputStream(file);
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        SentimentResponse response = rosetteApi.getSentiment(inputStream, "text/html", null, null);
+        SentimentResponse response = rosetteApi.getSentiment(inputStream, "text/html");
         inputStream.close();
         System.out.println(responseToJson(response));
     }

--- a/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
@@ -38,7 +38,7 @@ public final class TokensExample extends ExampleBase {
         String tokensData = "北京大学生物系主任办公室内部会议";
 
         RosetteAPI rosetteApi = new RosetteAPI(getApiKeyFromSystemProperty(), getAltUrlFromSystemProperty());
-        TokensResponse response = rosetteApi.getTokens(tokensData, null);
+        TokensResponse response = rosetteApi.getTokens(tokensData);
         System.out.println(responseToJson(response));
     }
 }


### PR DESCRIPTION
all endpoints except for name similarity updated to only take content as a parameter
API object uses builder syntax, users set attributes like language, genre, etc through builder methods
Examples and tests updated to reflect changes
