### PR TITLE
WS-1160 Removing restriction on Jackson's use of reflection

### DIFF
--- a/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
@@ -29,7 +29,6 @@ import com.basistech.rosette.apimodel.jackson.DocumentRequestMixin;
 import com.basistech.rosette.dm.AnnotatedText;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.io.ByteStreams;
@@ -153,7 +152,6 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
         }
 
         mapper = ApiModelMixinModule.setupObjectMapper(new ObjectMapper());
-        mapper.configure(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS, false);
         if (httpClient == null) {
             initClient(key, additionalHeaders);
         } else {

--- a/api/src/test/java/com/basistech/rosette/api/BasicTest.java
+++ b/api/src/test/java/com/basistech/rosette/api/BasicTest.java
@@ -161,7 +161,10 @@ public class BasicTest extends AbstractTest {
                             .withStatusCode(200)
                             .withHeader("Content-Type", "application/json")
                             .withBody(IOUtils.toString(respIns, "UTF-8")));
-            api = new HttpRosetteAPI("foo-key", String.format("http://localhost:%d/rest/v1", serverPort));
+            api = new HttpRosetteAPI.Builder()
+                    .key("foo-key")
+                    .url(String.format("http://localhost:%d/rest/v1", serverPort))
+                    .build();
             AnnotatedText testData = ApiModelMixinModule.setupObjectMapper(
                     new ObjectMapper()).readValue(reqIns, AnnotatedText.class);
             AnnotatedText resp = api.perform(HttpRosetteAPI.ENTITIES_SERVICE_PATH, new AdmRequest<>(testData, null, null, null));


### PR DESCRIPTION
And modifying unit test to correctly use the HttpRosetteAPI.Builder