### PR TITLE
Add ability to configure https proxy defined in java system properties

### DIFF
--- a/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
@@ -178,6 +178,7 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
         PoolingHttpClientConnectionManager cm = new PoolingHttpClientConnectionManager();
         cm.setMaxTotal(connectionConcurrency);
         builder.setConnectionManager(cm);
+        builder.useSystemProperties();
 
         initHeaders(key, additionalHeaders);
         builder.setDefaultHeaders(this.additionalHeaders);


### PR DESCRIPTION
Currently, you can't configure a https proxy to access rosette API.
This is a problem, particularly in enterprise, where there is often no direct access to internet.

With this PR, we can configure proxy using standard java configuration:
`export ES_JAVA_OPTS="-Dhttps.proxyHost=my-server -Dhttps.proxyPort=3128"`
