### PR TITLE
WS-1717: add dbpediaTypes and includeDBpediaTypes

### DIFF
--- a/api/src/test/mock-data/response/eng-url-entities.json
+++ b/api/src/test/mock-data/response/eng-url-entities.json
@@ -20,7 +20,8 @@
       "mention": "Washington", 
       "normalized": "Washington", 
       "type": "LOCATION",
-      "dbpediaType": [
+      "dbpediaType": "test1",
+      "dbpediaTypes": [
         "test1"
       ]
     }

--- a/api/src/test/mock-data/response/eng-url-entities_linked.json
+++ b/api/src/test/mock-data/response/eng-url-entities_linked.json
@@ -17,7 +17,7 @@
       "entityId": "Q1088831", 
       "indocChainId": 2, 
       "mention": "Washington",
-      "dbpediaType": [
+      "dbpediaTypes": [
         "test1",
         "foo",
         "bar"

--- a/json/src/test/data/EntitiesResponse.json
+++ b/json/src/test/data/EntitiesResponse.json
@@ -15,7 +15,8 @@
       "salience": 1.0,
       "confidence": 1.0,
       "linkingConfidence": 1.0,
-      "dbpediaType": [
+      "dbpediaType": "test1",
+      "dbpediaTypes": [
         "test1",
         "test2"
       ]

--- a/model/src/main/java/com/basistech/rosette/apimodel/EntitiesOptions.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/EntitiesOptions.java
@@ -58,9 +58,16 @@ public class EntitiesOptions extends Options {
     private final String modelType;
 
     /**
+     * @deprecated use includeDBpediaTypes instead.
      * @return the includeDBpediaType flag.
      */
     private final Boolean includeDBpediaType;
+
+    /**
+     * @since 1.14.0 (19.08)
+     * @return the includeDBpediaType flag.
+     */
+    private final Boolean includeDBpediaTypes;
 
     /**
      * @return the includePermID flag.

--- a/model/src/main/java/com/basistech/rosette/apimodel/Entity.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/Entity.java
@@ -83,9 +83,16 @@ public class Entity {
     private final Label sentiment;
 
     /**
+     * @deprecated use dbpediaTypes instead.
      * @return the DBpediaType
      */
-    private final List<String> dbpediaType;
+    private final String dbpediaType;
+
+    /**
+     * @since 1.14.0 (19.08)
+     * @return the DBpediaTypes
+     */
+    private final List<String> dbpediaTypes;
 
     /**
      * @return the PermID


### PR DESCRIPTION
 This PR add dbpediaTypes and includeDBpediaTypes. 
dbpediaType (singular) is reverted to the original string. 
includeDBpediaType and dbpediaType are marked deprecated, and scheduled to be removed in a 2020 feature release.