### PR TITLE
WS-2246: add generic reponse

### DIFF
--- a/model/src/main/java/com/basistech/rosette/apimodel/GenericResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/GenericResponse.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Basis Technology Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.basistech.rosette.apimodel;
+
+import com.basistech.rosette.annotations.JacksonMixin;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode
+@Builder
+@JacksonMixin
+public class GenericResponse extends Response {
+    private Object data;
+}


### PR DESCRIPTION
I propose GenericResponse with an object member "data". The purpose is to return a general purpose map returned from an info sub-endpoint.