### PR TITLE
WS-2464 - new internal release

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-examples</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-examples</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-examples</artifactId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>

--- a/osgi-itests/pom.xml
+++ b/osgi-itests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <properties>
         <bundle-repo>target/test-bundles</bundle-repo>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.basistech.rosette</groupId>
             <artifactId>rosette-api</artifactId>
-            <version>1.21.109-SNAPSHOT</version>
+            <version>1.21.108</version>
         </dependency>
 
         <!-- The goal of this test is to make sure rosette-api resolves successfully in OSGi with given dependencies. -->

--- a/osgi-itests/pom.xml
+++ b/osgi-itests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <properties>
         <bundle-repo>target/test-bundles</bundle-repo>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.basistech.rosette</groupId>
             <artifactId>rosette-api</artifactId>
-            <version>1.21.106-SNAPSHOT</version>
+            <version>1.21.108</version>
         </dependency>
 
         <!-- The goal of this test is to make sure rosette-api resolves successfully in OSGi with given dependencies. -->

--- a/osgi-itests/pom.xml
+++ b/osgi-itests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <properties>
         <bundle-repo>target/test-bundles</bundle-repo>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.basistech.rosette</groupId>
             <artifactId>rosette-api</artifactId>
-            <version>1.21.108</version>
+            <version>1.21.109-SNAPSHOT</version>
         </dependency>
 
         <!-- The goal of this test is to make sure rosette-api resolves successfully in OSGi with given dependencies. -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-java-binding</artifactId>
-    <version>1.21.106-SNAPSHOT</version>
+    <version>1.21.108</version>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rosette-api-java-binding-1.21.108</tag>
     </scm>
     <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-java-binding</artifactId>
-    <version>1.21.109-SNAPSHOT</version>
+    <version>1.21.108</version>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rosette-api-java-binding-1.21.108</tag>
     </scm>
     <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-java-binding</artifactId>
-    <version>1.21.108</version>
+    <version>1.21.109-SNAPSHOT</version>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
-        <tag>rosette-api-java-binding-1.21.108</tag>
+        <tag>HEAD</tag>
     </scm>
     <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
     <distributionManagement>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-release</artifactId>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.108</version>
+        <version>1.21.109-SNAPSHOT</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-release</artifactId>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.108</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-release</artifactId>


### PR DESCRIPTION
WS-2464: This PR is needed to create a brand new internal release for the java binding project, version: 1.21.108.