### PR TITLE
WS-2464 internal release

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -6,25 +6,10 @@ To be updated..
 
 #### Internal Releasing
 
-To perform an internal release, use `-Drelease-profile=internal-release` in `release:perform`.
-
-
-#### Old Stuff
-[Docker](examples/docker) bits for running examples.  Maybe just remove?
-
-A duplicate copy of the examples docker notes is below...
-
-Docker files can be found [here](https://github.com/rosette-api/java/tree/master/examples/docker)
-
-To simplify the running of the Java examples, the Dockerfile will build an image and install the rosette-api library from the *published source*.
-
-Build the docker image, e.g. `docker build --rm -t basistech/java:1.1 .`
-
-Run an example as `docker run --rm -e API_KEY=api-key -v "path-to-java-dir:/source" basistech/java:1.1`
-
-To test against a specific source file, add `-e FILENAME=filename` before the `-v`.
-To test against an alternate url, add `-e ALT_URL=alternate_url`.
-
-#### TODOs
-...
+To perform an internal release, execute the following commands:
+```
+$ mvn release:clean
+$ mvn release:prepare
+$ mvn release:perform -Drelease-profile=internal-release
+```
 

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-examples</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-examples</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-examples</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-examples</artifactId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>

--- a/model/src/main/java/com/basistech/rosette/apimodel/Response.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/Response.java
@@ -16,6 +16,7 @@
 
 package com.basistech.rosette.apimodel;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
  * In this version, they have nothing in common.
  */
 @Getter
+@EqualsAndHashCode
 public abstract class Response {
     /**
      * @return extended information

--- a/model/src/main/java/com/basistech/rosette/apimodel/SupportedLanguage.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/SupportedLanguage.java
@@ -24,12 +24,14 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.Value;
 import lombok.experimental.NonFinal;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * Supported language/script
  */
 @Value
 @Builder
+@Jacksonized
 @JacksonMixin
 public class SupportedLanguage {
     /**

--- a/model/src/main/java/com/basistech/rosette/apimodel/SupportedLanguagePair.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/SupportedLanguagePair.java
@@ -23,12 +23,14 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.Value;
 import lombok.experimental.NonFinal;
+import lombok.extern.jackson.Jacksonized;
 
 /**
  * Supported language/script/scheme pairs
  */
 @Value
 @Builder
+@Jacksonized
 @JacksonMixin
 public class SupportedLanguagePair {
     /**

--- a/osgi-itests/pom.xml
+++ b/osgi-itests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <properties>
         <bundle-repo>target/test-bundles</bundle-repo>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.basistech.rosette</groupId>
             <artifactId>rosette-api</artifactId>
-            <version>1.21.110</version>
+            <version>1.21.111-SNAPSHOT</version>
         </dependency>
 
         <!-- The goal of this test is to make sure rosette-api resolves successfully in OSGi with given dependencies. -->

--- a/osgi-itests/pom.xml
+++ b/osgi-itests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <properties>
         <bundle-repo>target/test-bundles</bundle-repo>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.basistech.rosette</groupId>
             <artifactId>rosette-api</artifactId>
-            <version>1.21.109</version>
+            <version>1.21.110-SNAPSHOT</version>
         </dependency>
 
         <!-- The goal of this test is to make sure rosette-api resolves successfully in OSGi with given dependencies. -->

--- a/osgi-itests/pom.xml
+++ b/osgi-itests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <properties>
         <bundle-repo>target/test-bundles</bundle-repo>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.basistech.rosette</groupId>
             <artifactId>rosette-api</artifactId>
-            <version>1.21.106-SNAPSHOT</version>
+            <version>1.21.109</version>
         </dependency>
 
         <!-- The goal of this test is to make sure rosette-api resolves successfully in OSGi with given dependencies. -->

--- a/osgi-itests/pom.xml
+++ b/osgi-itests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
          <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <properties>
         <bundle-repo>target/test-bundles</bundle-repo>
@@ -14,7 +14,7 @@
         <dependency>
             <groupId>com.basistech.rosette</groupId>
             <artifactId>rosette-api</artifactId>
-            <version>1.21.110-SNAPSHOT</version>
+            <version>1.21.110</version>
         </dependency>
 
         <!-- The goal of this test is to make sure rosette-api resolves successfully in OSGi with given dependencies. -->

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-java-binding</artifactId>
-    <version>1.21.109</version>
+    <version>1.21.110-SNAPSHOT</version>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
-        <tag>rosette-api-java-binding-1.21.109</tag>
+        <tag>HEAD</tag>
     </scm>
     <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-java-binding</artifactId>
-    <version>1.21.110</version>
+    <version>1.21.111-SNAPSHOT</version>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
-        <tag>rosette-api-java-binding-1.21.110</tag>
+        <tag>HEAD</tag>
     </scm>
     <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-java-binding</artifactId>
-    <version>1.21.110-SNAPSHOT</version>
+    <version>1.21.110</version>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rosette-api-java-binding-1.21.110</tag>
     </scm>
     <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-java-binding</artifactId>
-    <version>1.21.106-SNAPSHOT</version>
+    <version>1.21.109</version>
     <parent>
         <artifactId>open-source-parent</artifactId>
         <groupId>com.basistech</groupId>
@@ -31,7 +31,7 @@
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>rosette-api-java-binding-1.21.109</tag>
     </scm>
     <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
              exclusions to fail.  And javadoc does not like the generated annotations
              source in the models sub-module. And none of these versions work with
              JDK 1.7.  Hence the exclusion in Travis. -->
-        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>3.4.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
 	<mockserver-version>4.1.0</mockserver-version>
 	<nexus-staging-plugin-version>1.6.13</nexus-staging-plugin-version>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.106-SNAPSHOT</version>
+        <version>1.21.109</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-release</artifactId>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110</version>
+        <version>1.21.111-SNAPSHOT</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-release</artifactId>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.110-SNAPSHOT</version>
+        <version>1.21.110</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-release</artifactId>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.basistech.rosette</groupId>
         <artifactId>rosette-api-java-binding</artifactId>
-        <version>1.21.109</version>
+        <version>1.21.110-SNAPSHOT</version>
     </parent>
     <groupId>com.basistech.rosette</groupId>
     <artifactId>rosette-api-release</artifactId>


### PR DESCRIPTION
This PR is needed to release version 1.21.109 for the Java bindings API.