### PR TITLE
no-jira: fix jenkins skipping failed maven command return code

### DIFF
--- a/CI.Jenkinsfile
+++ b/CI.Jenkinsfile
@@ -27,7 +27,7 @@ node ("docker-light") {
                              echo && \
                              echo [INFO] Set file permissions to UID and GID of jenkins user for cleanup. && \
                              chown -R 9960:9960 /source && \
-                             exit \$maven_ret\"
+                             exit \$maven_ret\""
             }
         }
         postToTeams(true)

--- a/CI.Jenkinsfile
+++ b/CI.Jenkinsfile
@@ -22,10 +22,12 @@ node ("docker-light") {
                        bash -c \"apt-get update && \
                              apt-get install -y git && \
                              pushd /source && \
-                             /opt/maven-basis/bin/mvn --batch-mode clean install sonar:sonar $mySonarOpts && \
+                             /opt/maven-basis/bin/mvn --batch-mode clean install sonar:sonar $mySonarOpts; \
+                             maven_ret=\$?; \
                              echo && \
                              echo [INFO] Set file permissions to UID and GID of jenkins user for cleanup. && \
-                             chown -R 9960:9960 /source\""
+                             chown -R 9960:9960 /source && \
+                             exit \$maven_ret\"
             }
         }
         postToTeams(true)

--- a/CI.Jenkinsfile
+++ b/CI.Jenkinsfile
@@ -22,7 +22,7 @@ node ("docker-light") {
                        bash -c \"apt-get update && \
                              apt-get install -y git && \
                              pushd /source && \
-                             /opt/maven-basis/bin/mvn --batch-mode clean install sonar:sonar $mySonarOpts; \
+                             /opt/maven-basis/bin/mvn --batch-mode clean install sonar:sonar $mySonarOpts && \
                              echo && \
                              echo [INFO] Set file permissions to UID and GID of jenkins user for cleanup. && \
                              chown -R 9960:9960 /source\""

--- a/CI.Jenkinsfile
+++ b/CI.Jenkinsfile
@@ -23,11 +23,11 @@ node ("docker-light") {
                              apt-get install -y git && \
                              pushd /source && \
                              /opt/maven-basis/bin/mvn --batch-mode clean install sonar:sonar $mySonarOpts; \
-                             maven_ret=\$?; \
+                             maven_ret=\\\$?; \
                              echo && \
                              echo [INFO] Set file permissions to UID and GID of jenkins user for cleanup. && \
                              chown -R 9960:9960 /source && \
-                             exit \$maven_ret\""
+                             exit \\\$maven_ret\""
             }
         }
         postToTeams(true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,21 @@
 node ("docker-light") {
     def SOURCEDIR = pwd()
     try {
+        def mavenLocalRepo = "$JENKINS_HOME/maven-local-repositories/executor-$EXECUTOR_NUMBER"
         stage("Clean up") {
             step([$class: 'WsCleanup'])
+            sh "rm -rf $mavenLocalRepo"
         }
         stage("Checkout Code") {
             checkout scm
+        }
+        stage("Build") {
+            withMaven(maven: "Basis",
+                    mavenLocalRepo: mavenLocalRepo,
+                    publisherStrategy: "EXPLICIT") {
+                sh "mvn clean verify"
+            }
+
         }
         stage("Test with Docker") {
             echo "${env.ALT_URL}"

--- a/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
+++ b/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
@@ -46,7 +46,7 @@ final class RecordSimilarityDeserializerUtilities {
             if (fields.containsKey(fieldName)) {
                 final RecordSimilarityFieldInfo fieldInfo = fields.get(fieldName);
                 final RecordSimilarityField fieldData;
-                if (fieldInfo == null) {
+                if (fieldInfo == null || fieldInfo.getType() == null) {
                     throw new IllegalArgumentException("Unspecified field type for: " + fieldName);
                 }
                 switch (fieldInfo.getType()) {

--- a/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
+++ b/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
@@ -46,7 +46,7 @@ final class RecordSimilarityDeserializerUtilities {
             if (fields.containsKey(fieldName)) {
                 final RecordSimilarityFieldInfo fieldInfo = fields.get(fieldName);
                 final RecordSimilarityField fieldData;
-                if (fieldInfo == null || fieldInfo.getType() == null) {
+                if (fieldInfo.getType() == null) {
                     throw new IllegalArgumentException("Unspecified field type for: " + fieldName);
                 }
                 switch (fieldInfo.getType()) {


### PR DESCRIPTION
If the maven command failed, the execution continued and docker run returned with the exit code of the last command, which prevented Jenkins from detecting that the build failed