### PR TITLE
RLPNC-7512: Added info block to `RecordSimilarityResponse` and `RecodSimilarityResult` non-fork

### DIFF
--- a/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
+++ b/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
@@ -19,8 +19,11 @@ package com.basistech.rosette.apimodel.jackson.recordsimilaritydeserializers;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import com.basistech.rosette.apimodel.recordsimilarity.RecordSimilarityExplainInfo;
 import com.basistech.rosette.apimodel.recordsimilarity.RecordSimilarityResult;
@@ -59,12 +62,18 @@ final class RecordSimilarityDeserializerUtilities {
                 ? parseRecord(node.get("right"), jsonParser, fields)
                 : null;
         final String error = Optional.ofNullable(node.get("error")).map(JsonNode::asText).orElse(null);
+        List<String> info = Optional.ofNullable(node.get("info"))
+                .map(jsonNode -> StreamSupport.stream(jsonNode.spliterator(), false)
+                        .map(JsonNode::asText)
+                        .collect(Collectors.toList()))
+                .orElse(null);
         return RecordSimilarityResult.builder()
                 .score(score)
                 .left(left)
                 .right(right)
                 .explainInfo(explainInfo)
                 .error(error)
+                .info(info)
                 .build();
     }
 

--- a/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityResponseDeserializer.java
+++ b/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityResponseDeserializer.java
@@ -30,6 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class RecordSimilarityResponseDeserializer extends StdDeserializer<RecordSimilarityResponse> {
 
@@ -47,6 +49,11 @@ public class RecordSimilarityResponseDeserializer extends StdDeserializer<Record
         JsonNode fieldsNode = node.get("fields");
 
         Map<String, RecordSimilarityFieldInfo> fields = fieldsNode != null ? node.get("fields").traverse(jsonParser.getCodec()).readValueAs(FIELDS_TYPE_REFERENCE) : null;
+        List<String> info = Optional.ofNullable(node.get("info"))
+                            .map(jsonNode -> StreamSupport.stream(jsonNode.spliterator(), false)
+                                                          .map(JsonNode::asText)
+                                                          .collect(Collectors.toList()))
+                            .orElse(null);
         String errorMessage = Optional.ofNullable(node.get("errorMessage")).map(JsonNode::asText).orElse(null);
 
         JsonNode resultsNode = node.get("results");
@@ -60,6 +67,7 @@ public class RecordSimilarityResponseDeserializer extends StdDeserializer<Record
         return RecordSimilarityResponse.builder()
                 .fields(fields)
                 .results(results)
+                .info(info)
                 .errorMessage(errorMessage)
                 .build();
     }

--- a/json/src/test/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponseTest.java
+++ b/json/src/test/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponseTest.java
@@ -39,7 +39,7 @@ public class RecordSimilarityResponseTest {
 
     private static final ObjectMapper MAPPER = ApiModelMixinModule.setupObjectMapper(new ObjectMapper());
 
-    private static final String EXPECTED_JSON = "{\"fields\":{\"addr\":{\"type\":\"rni_address\",\"weight\":0.3},\"dob\":{\"type\":\"rni_date\",\"weight\":0.2},\"primaryName\":{\"type\":\"rni_name\",\"weight\":0.5}},\"results\":[{\"explainInfo\":{\"leftOnlyFields\":[\"addr\"],\"scoredFields\":{\"dob\":{\"calculatedWeight\":0.2857142857142857,\"finalScore\":0.74,\"rawScore\":0.8,\"weight\":0.5},\"primaryName\":{\"calculatedWeight\":0.7142857142857143,\"details\":\"any details\",\"finalScore\":0.85,\"rawScore\":0.99,\"weight\":0.5}}},\"left\":{\"addr\":{\"address\":\"123 Roadlane Ave\"},\"dob\":{\"date\":\"1993-04-16\"},\"primaryName\":{\"entityType\":\"PERSON\",\"language\":\"eng\",\"languageOfOrigin\":\"eng\",\"script\":\"Latn\",\"text\":\"Ethan R\"}},\"right\":{\"dob\":\"1993-04-16\",\"primaryName\":{\"text\":\"Seth R\"}},\"score\":0.87},{\"error\":\"Field foo not found in field mapping\",\"left\":{\"addr\":{\"address\":\"123 Roadlane Ave\"},\"dob\":{\"date\":\"1993-04-16\"},\"primaryName\":{\"entityType\":\"PERSON\",\"language\":\"eng\",\"languageOfOrigin\":\"eng\",\"script\":\"Latn\",\"text\":\"Ethan R\"}},\"right\":{\"dob\":\"1993-04-16\",\"primaryName\":{\"text\":\"Seth R\"}}}]}";
+    private static final String EXPECTED_JSON = "{\"fields\":{\"addr\":{\"type\":\"rni_address\",\"weight\":0.3},\"dob\":{\"type\":\"rni_date\",\"weight\":0.2},\"primaryName\":{\"type\":\"rni_name\",\"weight\":0.5}},\"info\":[\"Field threshold not found in properties! Defaulting to 0.0\",\"Field weight not found in fields! Defaulting to 1.0 for all entries\"],\"results\":[{\"explainInfo\":{\"leftOnlyFields\":[\"addr\"],\"scoredFields\":{\"dob\":{\"calculatedWeight\":0.2857142857142857,\"finalScore\":0.74,\"rawScore\":0.8,\"weight\":0.5},\"primaryName\":{\"calculatedWeight\":0.7142857142857143,\"details\":\"any details\",\"finalScore\":0.85,\"rawScore\":0.99,\"weight\":0.5}}},\"left\":{\"addr\":{\"address\":\"123 Roadlane Ave\"},\"dob\":{\"date\":\"1993-04-16\"},\"primaryName\":{\"entityType\":\"PERSON\",\"language\":\"eng\",\"languageOfOrigin\":\"eng\",\"script\":\"Latn\",\"text\":\"Ethan R\"}},\"right\":{\"dob\":\"1993-04-16\",\"primaryName\":{\"text\":\"Seth R\"}},\"score\":0.87},{\"error\":\"Field foo not found in field mapping\",\"info\":[\"Some info message\",\"Some other info message\"],\"left\":{\"addr\":{\"address\":\"123 Roadlane Ave\"},\"dob\":{\"date\":\"1993-04-16\"},\"primaryName\":{\"entityType\":\"PERSON\",\"language\":\"eng\",\"languageOfOrigin\":\"eng\",\"script\":\"Latn\",\"text\":\"Ethan R\"}},\"right\":{\"dob\":\"1993-04-16\",\"primaryName\":{\"text\":\"Seth R\"}}}]}";
 
     private static final RecordSimilarityResponse EXPECTED_RESPONSE;
 
@@ -120,7 +120,12 @@ public class RecordSimilarityResponseTest {
                                                     .date("1993-04-16")
                                                     .build()))
                                     .error("Field foo not found in field mapping")
+                                    .info(List.of("Some info message", "Some other info message"))
                                     .build()))
+                    .info(List.of(
+                            "Field threshold not found in properties! Defaulting to 0.0",
+                            "Field weight not found in fields! Defaulting to 1.0 for all entries")
+                    )
                     .build();
         } catch (JsonProcessingException e) {
             temp = RecordSimilarityResponse.builder().build();

--- a/json/src/test/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponseTest.java
+++ b/json/src/test/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponseTest.java
@@ -96,7 +96,7 @@ public class RecordSimilarityResponseTest {
                                                             .finalScore(0.85)
                                                             .details(MAPPER.readTree("\"any details\""))
                                                             .build()
-                                                    ))
+                                            ))
                                             .build())
                                     .build(),
                             RecordSimilarityResult.builder()

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponse.java
@@ -39,6 +39,12 @@ public class RecordSimilarityResponse extends Response {
      * @return list of record match results
      */
     @Valid List<RecordSimilarityResult> results;
+
+    /**
+     * @return info messages to user, that could hold additional information about the results
+     */
+    @Valid List<String> info;
+
     /**
      * @return error message to user in case no results matched the threshold
      */

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResult.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResult.java
@@ -16,6 +16,7 @@
 
 package com.basistech.rosette.apimodel.recordsimilarity;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -32,5 +33,6 @@ public class RecordSimilarityResult {
     Map<String, RecordSimilarityField> left;
     Map<String, RecordSimilarityField> right;
     RecordSimilarityExplainInfo explainInfo;
+    List<String> info;
     String error;
 }


### PR DESCRIPTION
Copy of #231 That was opened from a fork and Sonar couldn't run on itl.