### PR TITLE
RLPNC-7509: record similarity properties validation from fork

### DIFF
--- a/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
+++ b/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityDeserializerUtilities.java
@@ -62,7 +62,7 @@ final class RecordSimilarityDeserializerUtilities {
                 ? parseRecord(node.get("right"), jsonParser, fields)
                 : null;
         final String error = Optional.ofNullable(node.get("error")).map(JsonNode::asText).orElse(null);
-        List<String> info = Optional.ofNullable(node.get("info"))
+        final List<String> info = Optional.ofNullable(node.get("info"))
                 .map(jsonNode -> StreamSupport.stream(jsonNode.spliterator(), false)
                         .map(JsonNode::asText)
                         .collect(Collectors.toList()))

--- a/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityResponseDeserializer.java
+++ b/json/src/main/java/com/basistech/rosette/apimodel/jackson/recordsimilaritydeserializers/RecordSimilarityResponseDeserializer.java
@@ -50,10 +50,10 @@ public class RecordSimilarityResponseDeserializer extends StdDeserializer<Record
 
         Map<String, RecordSimilarityFieldInfo> fields = fieldsNode != null ? node.get("fields").traverse(jsonParser.getCodec()).readValueAs(FIELDS_TYPE_REFERENCE) : null;
         List<String> info = Optional.ofNullable(node.get("info"))
-                            .map(jsonNode -> StreamSupport.stream(jsonNode.spliterator(), false)
-                                                          .map(JsonNode::asText)
-                                                          .collect(Collectors.toList()))
-                            .orElse(null);
+                .map(jsonNode -> StreamSupport.stream(jsonNode.spliterator(), false)
+                        .map(JsonNode::asText)
+                        .collect(Collectors.toList()))
+                .orElse(null);
         String errorMessage = Optional.ofNullable(node.get("errorMessage")).map(JsonNode::asText).orElse(null);
 
         JsonNode resultsNode = node.get("results");

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityProperties.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityProperties.java
@@ -20,7 +20,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
@@ -30,9 +29,8 @@ import lombok.extern.jackson.Jacksonized;
 @Value
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecordSimilarityProperties {
-    @Builder.Default
-    @NotNull @Valid Double threshold = 0.0;
-    @NotNull @Valid Boolean includeExplainInfo;
+    @Valid Double threshold;
+    @Valid Boolean includeExplainInfo;
     @Valid Map<String, String> parameters;
     @Valid String parameterUniverse;
 }

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResponse.java
@@ -43,6 +43,7 @@ public class RecordSimilarityResponse extends Response {
     /**
      * @return info messages to user, that could hold additional information about the results
      */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     @Valid List<String> info;
 
     /**

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResult.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResult.java
@@ -33,6 +33,9 @@ public class RecordSimilarityResult {
     Map<String, RecordSimilarityField> left;
     Map<String, RecordSimilarityField> right;
     RecordSimilarityExplainInfo explainInfo;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     List<String> info;
+
     String error;
 }

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResult.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityResult.java
@@ -33,6 +33,8 @@ public class RecordSimilarityResult {
     Map<String, RecordSimilarityField> left;
     Map<String, RecordSimilarityField> right;
     RecordSimilarityExplainInfo explainInfo;
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     List<String> error;
 
     @JsonInclude(JsonInclude.Include.NON_EMPTY)


### PR DESCRIPTION
# :heavy_check_mark:  Threshold and includeExplainInfo can be null

RNI-RNT will assign them a default value and return a message inside the response in case they are null, so the validations aren't necessary here any longer. More, they prevent the SDK from working properly, so I removed them.

# :art:  If info is empty, it should not be in the response

This one can change, however for now, I modified the info field to not include `"info":  []` in the response object.

# :detective: For the reviewers
:exclamation:  This is a copy of #237 . In theory nothing should be different in the code.