### PR TITLE
RLPNC-7496: Removed unneeded validation/enforcement, added getter

### DIFF
--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityFieldInfo.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityFieldInfo.java
@@ -19,6 +19,7 @@ package com.basistech.rosette.apimodel.recordsimilarity;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import javax.validation.Valid;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
@@ -29,7 +30,7 @@ import javax.validation.constraints.NotNull;
 @Value
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecordSimilarityFieldInfo {
-    @NotNull @Valid String type;
+    @Getter @NotNull @Valid String type;
     Double weight;
     /**
      * the score that this field should return if the field is null in a record

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityFieldInfo.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityFieldInfo.java
@@ -19,7 +19,6 @@ package com.basistech.rosette.apimodel.recordsimilarity;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import javax.validation.Valid;
 import lombok.Builder;
-import lombok.Getter;
 import lombok.Value;
 import lombok.extern.jackson.Jacksonized;
 
@@ -30,7 +29,7 @@ import javax.validation.constraints.NotNull;
 @Value
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecordSimilarityFieldInfo {
-    @Getter @NotNull @Valid String type;
+    @NotNull @Valid String type;
     Double weight;
     /**
      * the score that this field should return if the field is null in a record

--- a/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityRequest.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/recordsimilarity/RecordSimilarityRequest.java
@@ -22,14 +22,13 @@ import javax.validation.Valid;
 import lombok.Value;
 import lombok.Builder;
 
-import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import java.util.Map;
 
 @Value
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class RecordSimilarityRequest extends Request {
-    @NotEmpty @Valid Map<String, RecordSimilarityFieldInfo> fields;
+    @Valid Map<String, RecordSimilarityFieldInfo> fields;
     @Valid RecordSimilarityProperties properties;
     @NotNull @Valid RecordSimilarityRecords records;
 


### PR DESCRIPTION
The SDK handles validation of too few (and too many) fields in the mapping - to keep error messages consistent (like on Rosette Server), the annotation is removed. The getter was added to `RecordSimilarityFieldInfo` to get successful builds - I think this change has likely been introduced in other PRs as well.