### PR TITLE
Ws 3314 update key header and urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <picture>
   <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon.png">
   <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-white.png">
-  <img alt="Babel Street Logo" width="47" height="60">
+  <img alt="Babel Street Logo" width="60" height="60">
 </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <a href="https://www.babelstreet.com/rosette">
 <picture>
-  <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon.png">
-  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-white.png">
-  <img alt="Babel Street Logo" width="60" height="60">
+  <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon-dark.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-ligth.png">
+  <img alt="Babel Street Logo" width="48" height="48">
 </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Rosette uses natural language processing, statistical modeling, and machine lear
 
 
 ## Rosette API Access
-- Rosette Cloud [Sign Up](https://developer.rosette.com/signup)
+- Rosette Cloud [Sign Up](https://developer.babelstreet.com/signup)
 ## Quick Start
 
 #### Maven
@@ -26,7 +26,7 @@ in the Maven Central badge at the top of this page.
 
 #### Test Releases
 Versions, of the form `x.y.z`, where `z` is greater than or equal to `100`, are internal testing versions.  Do not use
-them without consultation with Basis Technology Corp.
+them without consultation with Babel Street.(???)
 
 #### Examples
 View small example programs for each Rosette endpoint in the
@@ -36,7 +36,7 @@ View small example programs for each Rosette endpoint in the
 - [Binding API](https://rosette-api.github.io/java/)
 - [Rosette Platform API](https://docs.babelstreet.com/API/en/index-en.html)
 - [Binding Release Notes](https://github.com/rosette-api/java/wiki/Release-Notes)
-- [Rosette Platform Release Notes](https://babelstreet.my.site.com/support/s/article/Rosette-Cloud-Release-Notes)
+- [Rosette Platform Release Notes](https://docs.babelstreet.com/Release/en/rosette-cloud.html)
 - [Support](https://babelstreet.my.site.com/support/s/)
 - [Binding License: Apache 2.0](LICENSE.txt)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://www.babelstreet.com/rosette">
 <picture>
   <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon-dark.png">
-  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-ligth.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-light.png">
   <img alt="Babel Street Logo" width="48" height="48">
 </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,25 @@
 <a href="https://www.babelstreet.com/rosette"><img src="https://charts.babelstreet.com/icon.png" width="47" height="60"/></a>
-# Rosette by Babel Street
+# Analytics by Babel Street
 
 ---
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.basistech.rosette/rosette-api/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.basistech.rosette/rosette-api-java-binding)
 
-Rosette uses natural language processing, statistical modeling, and machine learning to analyze unstructured and semi-structured text across hundreds of language-script combinations, revealing valuable information and actionable data. Rosette provides endpoints for extracting entities and relationships, translating and comparing the similarity of names, categorizing and adding linguistic tags to text and more. Rosette Server is the on-premises installation of Rosette, with access to Rosette's functions as RESTful web service endpoints. This solves cloud security worries and allows customization (models/indexes) as needed for your business.
+Our product is a full text processing pipeline from data preparation to extracting the most relevant information and 
+analysis utilizing precise, focused AI that has built-in human understanding. Text Analytics provides foundational 
+linguistic analysis for identifying languages and relating words. The result is enriched and normalized text for 
+high-speed search and processing without translation.
 
+Text Analytics extracts events and entities — people, organizations, and places — from unstructured text and adds the 
+structure of associating those entities into events that deliver only the necessary information for near real-time 
+decision making. Accompanying tools shorten the process of training AI models to recognize domain-specific events.
 
-## Rosette API Access
-- Rosette Cloud [Sign Up](https://developer.babelstreet.com/signup)
+The product delivers a multitude of ways to sharpen and expand search results. Semantic similarity expands search 
+beyond keywords to words with the same meaning, even in other languages. Sentiment analysis and topic extraction help 
+filter results to what’s relevant.
+
+## Analytics API Access
+- Analytics Cloud [Sign Up](https://developer.babelstreet.com/signup)
 ## Quick Start
 
 #### Maven
@@ -26,7 +36,7 @@ in the Maven Central badge at the top of this page.
 
 #### Test Releases
 Versions, of the form `x.y.z`, where `z` is greater than or equal to `100`, are internal testing versions.  Do not use
-them without consultation with Babel Street.(???)
+them without consultation with Babel Street.
 
 #### Examples
 View small example programs for each Rosette endpoint in the
@@ -34,9 +44,9 @@ View small example programs for each Rosette endpoint in the
 
 #### Documentation & Support
 - [Binding API](https://rosette-api.github.io/java/)
-- [Rosette Platform API](https://docs.babelstreet.com/API/en/index-en.html)
+- [Analytics Platform API](https://docs.babelstreet.com/API/en/index-en.html)
 - [Binding Release Notes](https://github.com/rosette-api/java/wiki/Release-Notes)
-- [Rosette Platform Release Notes](https://docs.babelstreet.com/Release/en/rosette-cloud.html)
+- [Analytics Platform Release Notes](https://docs.babelstreet.com/Release/en/rosette-cloud.html)
 - [Support](https://babelstreet.my.site.com/support/s/)
 - [Binding License: Apache 2.0](LICENSE.txt)
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Versions, of the form `x.y.z`, where `z` is greater than or equal to `100`, are 
 them without consultation with Babel Street.
 
 #### Examples
-View small example programs for each Rosette endpoint in the
+View small example programs for each Analytics endpoint in the
 [examples](examples/src/main/java/com/basistech/rosette/examples) directory.
 
 #### Documentation & Support

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://www.babelstreet.com/rosette">
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon.png">
-  <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon-white.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon.png">
+  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon-white.png">
   <img alt="Babel Street Logo" width="47" height="60">
 </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-<a href="https://www.babelstreet.com/rosette"><img src="https://charts.babelstreet.com/icon.png" width="47" height="60"/></a>
+<a href="https://www.babelstreet.com/rosette">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://charts.babelstreet.com/icon.png">
+  <source media="(prefers-color-scheme: light)" srcset="https://charts.babelstreet.com/icon-white.png">
+  <img alt="Babel Street Logo" width="47" height="60">
+</picture>
+</a>
+
 # Analytics by Babel Street
 
 ---

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <artifactId>rosette-api-all</artifactId>
     <name>rosette-api-all</name>
-    <description>Analytics API all modules combined</description>
+    <description>Babel Street Analytics API all modules combined</description>
     <dependencies>
         <dependency>
             <groupId>com.basistech</groupId>

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <artifactId>rosette-api-all</artifactId>
     <name>rosette-api-all</name>
-    <description>Rosette API all modules combined</description>
+    <description>Analytics API all modules combined</description>
     <dependencies>
         <dependency>
             <groupId>com.basistech</groupId>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <artifactId>rosette-api-annotations</artifactId>
     <name>rosette-api-annotations</name>
-    <description>Rosette API Annotations</description>
+    <description>Babel Street Analytics API Annotations</description>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <artifactId>rosette-api</artifactId>
     <name>rosette-api</name>
-    <description>Rosette API Communications</description>
+    <description>Babel Street Analytics API Communications</description>
     <properties>
         <skip-mockserver>false</skip-mockserver>
     </properties>

--- a/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
@@ -83,7 +83,7 @@ import static java.net.HttpURLConnection.HTTP_OK;
  */
 public class HttpRosetteAPI extends AbstractRosetteAPI {
 
-    public static final String DEFAULT_URL_BASE = "https://api.rosette.com/rest/v1";
+    public static final String DEFAULT_URL_BASE = "https://analytics.babelstreet.com/rest/v1";
     public static final String SERVICE_NAME = "RosetteAPI";
     public static final String BINDING_VERSION = getVersion();
     public static final String USER_AGENT_STR = SERVICE_NAME + "-Java/" + BINDING_VERSION + "/"
@@ -197,7 +197,7 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
         this.additionalHeaders.add(new BasicHeader(HttpHeaders.USER_AGENT, USER_AGENT_STR));
         this.additionalHeaders.add(new BasicHeader(HttpHeaders.ACCEPT_ENCODING, "gzip"));
         if (key != null) {
-            this.additionalHeaders.add(new BasicHeader("X-RosetteAPI-Key", key));
+            this.additionalHeaders.add(new BasicHeader("X-BabelStreetAPI-Key", key));
             this.additionalHeaders.add(new BasicHeader("X-RosetteAPI-Binding", "java"));
             this.additionalHeaders.add(new BasicHeader("X-RosetteAPI-Binding-Version", BINDING_VERSION));
         }

--- a/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
+++ b/api/src/main/java/com/basistech/rosette/api/HttpRosetteAPI.java
@@ -79,7 +79,7 @@ import java.util.zip.GZIPInputStream;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 /**
- * Access to the RosetteAPI via HTTP.
+ * Access to the Analytics API via HTTP.
  */
 public class HttpRosetteAPI extends AbstractRosetteAPI {
 
@@ -104,16 +104,16 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
     }
 
     /**
-     * Constructs a Rosette API instance using the builder syntax.
+     * Constructs an Analytics API instance using the builder syntax.
      *
-     * @param key            Rosette API key. This may be null for use with an on-premise deployment
-     *                     of the Rosette API.
-     * @param urlToCall   Alternate Rosette API URL. {@code null} uses the default, public, URL.
+     * @param key            Analytics API key. This may be null for use with an on-premise deployment
+     *                     of the Analytics API.
+     * @param urlToCall   Alternate Analytics API URL. {@code null} uses the default, public, URL.
      * @param failureRetries Number of times to retry in case of failure; {@code null} uses the
      *                       default value: 1.
      * @param connectionConcurrency Number of concurrent connections. Pass this if have subscribed
      *                              to a plan that supports enhanced concurrency, or if you are using
-     *                              an on-premise deployment of the Rosette API. {@code null} uses the
+     *                              an on-premise deployment of the Analytics API. {@code null} uses the
      *                              default value: 2.
      * @throws HttpRosetteAPIException  Problem with the API request
      */
@@ -216,10 +216,10 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
     }
 
     /**
-     * Gets information about the Rosette API, returns name, version, build number and build time.
+     * Gets information about the Analytics API, returns name, version, build number and build time.
      *
      * @return InfoResponse
-     * @throws HttpRosetteAPIException Rosette specific exception
+     * @throws HttpRosetteAPIException Analytics specific exception
      * @throws IOException         General IO exception
      */
     public InfoResponse info() throws IOException, HttpRosetteAPIException {
@@ -227,10 +227,10 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
     }
 
     /**
-     * Pings the Rosette API for a response indicating that the service is available.
+     * Pings the Analytics API for a response indicating that the service is available.
      *
      * @return PingResponse
-     * @throws HttpRosetteAPIException Rosette specific exception
+     * @throws HttpRosetteAPIException Analytics specific exception
      * @throws IOException         General IO exception
      */
     public PingResponse ping() throws IOException, HttpRosetteAPIException {
@@ -238,10 +238,10 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
     }
 
     /**
-     * Gets the set of language and script codes supported by the specified Rosette API endpoint.
+     * Gets the set of language and script codes supported by the specified Analytics API endpoint.
      *
      * @return SupportedLanguagesResponse
-     * @throws HttpRosetteAPIException for an error returned from the Rosette API.
+     * @throws HttpRosetteAPIException for an error returned from the Analytics API.
      */
     @Override
     public SupportedLanguagesResponse getSupportedLanguages(String endpoint) throws HttpRosetteAPIException  {
@@ -254,12 +254,12 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
     }
 
     /**
-     * Gets the set of language, script codes and transliteration scheme pairs supported by the specified Rosette API
+     * Gets the set of language, script codes and transliteration scheme pairs supported by the specified Analytics API
      * endpoint.
      *
-     * @param endpoint Rosette API endpoint.
+     * @param endpoint Analytics API endpoint.
      * @return SupportedLanguagePairsResponse
-     * @throws HttpRosetteAPIException for an error returned from the Rosette API.
+     * @throws HttpRosetteAPIException for an error returned from the Analytics API.
      */
     @Override
     public SupportedLanguagePairsResponse getSupportedLanguagePairs(String endpoint) throws HttpRosetteAPIException  {
@@ -279,7 +279,7 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
      * @param <RequestType> the type of the request object.
      * @param <ResponseType> the type of the response object.
      * @return the response.
-     * @throws HttpRosetteAPIException for an error returned from the Rosette API.
+     * @throws HttpRosetteAPIException for an error returned from the Analytics API.
      * @throws RosetteRuntimeException for other errors, such as communications problems with HTTP.
      */
     @Override
@@ -300,7 +300,7 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
      * @param request the data for the request.
      * @param <RequestType> the type of the request object.
      * @return the response, {@link com.basistech.rosette.dm.AnnotatedText}.
-     * @throws HttpRosetteAPIException for an error returned from the Rosette API.
+     * @throws HttpRosetteAPIException for an error returned from the Analytics API.
      * @throws RosetteRuntimeException for other errors, such as communications problems with HTTP.
      */
     @Override
@@ -326,11 +326,11 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
     }
 
     /**
-     * Sends a GET request to Rosette API.
+     * Sends a GET request to Analytics API.
      * <p>
      * Returns a Response.
      *
-     * @param urlStr Rosette API end point.
+     * @param urlStr Analytics API end point.
      * @param clazz  Response class
      * @return Response
      * @throws HttpRosetteAPIException
@@ -351,11 +351,11 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
     }
 
     /**
-     * Sends a POST request to Rosette API.
+     * Sends a POST request to Analytics API.
      * <p>
      * Returns a Response.
      *
-     * @param urlStr Rosette API end point.
+     * @param urlStr Analytics API end point.
      * @param clazz  Response class
      * @return Response
      * @throws IOException
@@ -570,7 +570,7 @@ public class HttpRosetteAPI extends AbstractRosetteAPI {
                     }
                     if (429 == status) {
                         String concurrencyMessage = "You have exceeded your plan's limit on concurrent calls. "
-                                + "This could be caused by multiple processes or threads making Rosette API calls "
+                                + "This could be caused by multiple processes or threads making Analytics API calls "
                                 + "in parallel, or if your httpClient is configured with higher concurrency "
                                 + "than your plan allows.";
                         if (emHeader == null) {

--- a/api/src/main/java/com/basistech/rosette/api/MorphologicalFeature.java
+++ b/api/src/main/java/com/basistech/rosette/api/MorphologicalFeature.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2014-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/api/src/main/java/com/basistech/rosette/api/MorphologicalFeature.java
+++ b/api/src/main/java/com/basistech/rosette/api/MorphologicalFeature.java
@@ -17,7 +17,7 @@
 package com.basistech.rosette.api;
 
 /**
- * Specify which feature you want Rosette API Morphology endpoint to return. Specify COMPLETE for every feature.
+ * Specify which feature you want Analytics API Morphology endpoint to return. Specify COMPLETE for every feature.
  */
 public enum MorphologicalFeature {
     COMPLETE("complete"),

--- a/api/src/main/java/com/basistech/rosette/api/MorphologicalFeature.java
+++ b/api/src/main/java/com/basistech/rosette/api/MorphologicalFeature.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/api/src/test/java/com/basistech/rosette/api/BasicTest.java
+++ b/api/src/test/java/com/basistech/rosette/api/BasicTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ class BasicTest {
                 .withHeader(HttpHeaders.USER_AGENT, HttpRosetteAPI.USER_AGENT_STR))
                 .respond(HttpResponse.response()
                         .withHeader("Content-Type", "application/json")
-                        .withHeader("X-RosetteAPI-Concurrency", "5")
+                        .withHeader("X-BabelStreetAPI-Concurrency", "5")
                         .withStatusCode(200)
                         .withBody("{\"message\":\"Rosette API at your service\",\"time\":1461788498633}", StandardCharsets.UTF_8));
 
@@ -148,7 +148,7 @@ class BasicTest {
                 .additionalHeader("X-Foo", "Bar")
                 .build();
         var resp = api.ping();
-        assertEquals("5", resp.getExtendedInformation().get("X-RosetteAPI-Concurrency"));
+        assertEquals("5", resp.getExtendedInformation().get("X-BabelStreetAPI-Concurrency"));
     }
 
     @Test
@@ -185,7 +185,7 @@ class BasicTest {
                         .withHeader("Content-Type", "application/json")
                         .withHeader("X-Foo", "Bar")
                         .withHeader("X-FooMulti", "Bar1", "Bar2")
-                        .withHeader("X-RosetteAPI-Concurrency", "5")
+                        .withHeader("X-BabelStreetAPI-Concurrency", "5")
                         .withBody("{\"message\":\"Rosette API at your service\",\"time\":1461788498633}", StandardCharsets.UTF_8));
         api = new HttpRosetteAPI.Builder()
                 .key("foo-key")

--- a/api/src/test/java/com/basistech/rosette/api/InvalidErrorTest.java
+++ b/api/src/test/java/com/basistech/rosette/api/InvalidErrorTest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class InvalidErrorTest {
         mockServer.when(HttpRequest.request().withPath(".*/{2,}.*"))
                 .respond(HttpResponse.response()
                             .withBody("Invalid path; '//'")
-                            .withHeader("X-RosetteAPI-Concurrency", "5")
+                            .withHeader("X-BabelStreetAPI-Concurrency", "5")
                             .withStatusCode(HTTP_NOT_FOUND));
         mockServer.when(HttpRequest.request()
                 .withMethod("GET")
@@ -59,7 +59,7 @@ class InvalidErrorTest {
                 .respond(HttpResponse.response()
                         .withBody("{\"message\":\"Rosette API at your service\",\"time\":1461788498633}", StandardCharsets.UTF_8)
                         .withStatusCode(HTTP_OK)
-                        .withHeader("X-RosetteAPI-Concurrency", "5"));
+                        .withHeader("X-BabelStreetAPI-Concurrency", "5"));
         String mockServiceUrl = "http://localhost:" + mockServer.getPort() + "/rest//v1";
         boolean exceptional = false;
         try {

--- a/api/src/test/java/com/basistech/rosette/api/RosetteAPITest.java
+++ b/api/src/test/java/com/basistech/rosette/api/RosetteAPITest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -100,14 +100,14 @@ class RosetteAPITest {
                         .withBody("{\"message\":\"Rosette API at your service\",\"time\":1461788498633}",
                                 StandardCharsets.UTF_8)
                         .withStatusCode(HTTP_OK)
-                        .withHeader("X-RosetteAPI-Concurrency", "5"));
+                        .withHeader("X-BabelStreetAPI-Concurrency", "5"));
 
         this.mockServer.when(HttpRequest.request()
                 .withPath("/info"))
             .respond(HttpResponse.response()
                 .withStatusCode(HTTP_OK)
                 .withHeader("Content-Type", "application/json")
-                .withHeader("X-RosetteAPI-Concurrency", "5")
+                .withHeader("X-BabelStreetAPI-Concurrency", "5")
                 .withBody(INFO_RESPONSE, StandardCharsets.UTF_8));
 
         api = new HttpRosetteAPI.Builder()
@@ -145,14 +145,14 @@ class RosetteAPITest {
                     .respond(HttpResponse.response()
                             .withHeader("Content-Type", "application/json")
                             .withHeader("Content-Encoding", "gzip")
-                            .withHeader("X-RosetteAPI-Concurrency", "5")
+                            .withHeader("X-BabelStreetAPI-Concurrency", "5")
                             .withStatusCode(statusCode).withBody(gzip(responseStr)));
 
         } else {
             mockServer.when(HttpRequest.request().withPath("^(?!/info).+"))
                     .respond(HttpResponse.response()
                             .withHeader("Content-Type", "application/json")
-                            .withHeader("X-RosetteAPI-Concurrency", "5")
+                            .withHeader("X-BabelStreetAPI-Concurrency", "5")
                             .withStatusCode(statusCode).withBody(responseStr, StandardCharsets.UTF_8));
         }
 

--- a/api/src/test/java/com/basistech/rosette/api/RosetteRequestTest.java
+++ b/api/src/test/java/com/basistech/rosette/api/RosetteRequestTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Basis Technology Corp.
+ * Copyright 2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ class RosetteRequestTest {
         this.mockServer.when(HttpRequest.request().withPath(requestPath), Times.exactly(requestTimes))
                 .respond(HttpResponse.response()
                         .withHeader("Content-Type", "application/json")
-                        .withHeader("X-RosetteAPI-Concurrency", "5")
+                        .withHeader("X-BabelStreetAPI-Concurrency", "5")
                         .withStatusCode(statusCode)
                         .withBody(responseString)
                         .withDelay(TimeUnit.MILLISECONDS, delayMillis));

--- a/api/src/test/mock-data/mockgen.py
+++ b/api/src/test/mock-data/mockgen.py
@@ -50,7 +50,7 @@ args = parser.parse_args()
 
 headers = {"Content-Type": "application/json"}
 if args.api_key:
-    headers['X-RosetteAPI-Key'] = args.api_key
+    headers['X-BabelStreetAPI-Key'] = args.api_key
 
 # prep & clean up
 for folder in ["request", "response"]:

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <artifactId>rosette-api-common</artifactId>
     <name>rosette-api-common</name>
-    <description>Rosette API Common</description>
+    <description>Babel Street Analytics API Common</description>
     <dependencies>
         <dependency>
             <groupId>com.basistech.rosette</groupId>

--- a/common/src/main/java/com/basistech/rosette/api/common/AbstractRosetteAPI.java
+++ b/common/src/main/java/com/basistech/rosette/api/common/AbstractRosetteAPI.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/common/src/main/java/com/basistech/rosette/api/common/AbstractRosetteAPI.java
+++ b/common/src/main/java/com/basistech/rosette/api/common/AbstractRosetteAPI.java
@@ -29,7 +29,7 @@ import com.basistech.rosette.apimodel.SupportedLanguagesResponse;
 import com.basistech.rosette.dm.AnnotatedText;
 
 /**
- * This class defines the common API to Rosette, whether over HTTP or other integration mechanisms.
+ * This class defines the common API to Analytics, whether over HTTP or other integration mechanisms.
  */
 public abstract class AbstractRosetteAPI implements AutoCloseable {
 
@@ -89,19 +89,19 @@ public abstract class AbstractRosetteAPI implements AutoCloseable {
     ));
 
     /**
-     * Gets the set of language and script codes supported by the specified Rosette API endpoint.
+     * Gets the set of language and script codes supported by the specified Analytics API endpoint.
      *
-     * @param endpoint Rosette API endpoint.
+     * @param endpoint Analytics API endpoint.
      * @return SupportedLanguagesResponse
      * @throws CommonRosetteAPIException for an error.
      */
     public abstract SupportedLanguagesResponse getSupportedLanguages(String endpoint) throws CommonRosetteAPIException;
 
     /**
-     * Gets the set of language, script codes and transliteration scheme pairs supported by the specified Rosette API
+     * Gets the set of language, script codes and transliteration scheme pairs supported by the specified Analytics API
      * endpoint.
      *
-     * @param endpoint Rosette API endpoint.
+     * @param endpoint Analytics API endpoint.
      * @return SupportedLanguagePairsResponse
      * @throws CommonRosetteAPIException for an error returned from the Rosette API.
      */
@@ -109,7 +109,7 @@ public abstract class AbstractRosetteAPI implements AutoCloseable {
             throws CommonRosetteAPIException;
 
     /**
-     * Perform a request to an endpoint of the Rosette API.
+     * Perform a request to an endpoint of the Analytics API.
      * @param endpoint which endpoint.
      * @param request the data for the request.
      * @param <RequestType> The class of the request object for this endpoint.
@@ -123,7 +123,7 @@ public abstract class AbstractRosetteAPI implements AutoCloseable {
             throws CommonRosetteAPIException;
 
     /**
-     * Perform a request to an endpoint of the Rosette API.
+     * Perform a request to an endpoint of the Analytics API.
      * @param endpoint which endpoint.
      * @param request the data for the request.
      * @param <RequestType> The class of the request object for this endpoint.
@@ -134,7 +134,7 @@ public abstract class AbstractRosetteAPI implements AutoCloseable {
             throws CommonRosetteAPIException;
 
     /**
-     * Start an asynchronous request to an endpoint of the Rosette API.
+     * Start an asynchronous request to an endpoint of the Analytics API.
      * @param endpoint which endpoint.
      * @param request the data for the request.
      * @param <RequestType> The class of the request object for this endpoint.

--- a/common/src/main/java/com/basistech/rosette/api/common/AbstractRosetteAPI.java
+++ b/common/src/main/java/com/basistech/rosette/api/common/AbstractRosetteAPI.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/AddressSimilarityExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/AddressSimilarityExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Basis Technology Corp.
+ * Copyright 2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/AddressSimilarityExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/AddressSimilarityExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Basis Technology Corp.
+ * Copyright 2022-2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/AddressSimilarityExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/AddressSimilarityExample.java
@@ -57,7 +57,7 @@ public final class AddressSimilarityExample extends ExampleBase {
         UnfieldedAddress address2 = UnfieldedAddress.builder()
                 .address(addressSimilarityAddress2)
                 .build();
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -67,7 +67,7 @@ public final class AddressSimilarityExample extends ExampleBase {
                                                 .address1(address1)
                                                 .address2(address2)
                                                 .build();
-        AddressSimilarityResponse response = rosetteApi
+        AddressSimilarityResponse response = api
                 .perform(ADDRESS_SIMILARITY_SERVICE_PATH, request, AddressSimilarityResponse.class);
 
         System.out.println(responseToJson(response));

--- a/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/CategoriesExample.java
@@ -43,7 +43,7 @@ public final class CategoriesExample extends ExampleBase {
 
     private void run() throws IOException {
         String categoriesTextData = "If you are a fan of the British television series Downton Abbey and you are planning to be in New York anytime before April 2nd, there is a perfect stop for you while in town.";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                 .key(getApiKeyFromSystemProperty())
                                 .url(getAltUrlFromSystemProperty())
                                 .build();
@@ -52,7 +52,7 @@ public final class CategoriesExample extends ExampleBase {
         DocumentRequest<CategoriesOptions> request = DocumentRequest.<CategoriesOptions>builder()
                                                                     .content(categoriesTextData)
                                                                     .build();
-        CategoriesResponse response = rosetteApi.perform(CATEGORIES_SERVICE_PATH, request, CategoriesResponse.class);
+        CategoriesResponse response = api.perform(CATEGORIES_SERVICE_PATH, request, CategoriesResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/ConcurrencyExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ConcurrencyExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Basis Technology Corp.
+ * Copyright 2023-2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/ConcurrencyExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ConcurrencyExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Basis Technology Corp.
+ * Copyright 2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/ConcurrencyExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ConcurrencyExample.java
@@ -64,7 +64,7 @@ public final class ConcurrencyExample extends ExampleBase {
     private  void run() throws IOException, ExecutionException, InterruptedException {
         //Setting up the Api
         int maximumConcurrency = 3;
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .connectionConcurrency(maximumConcurrency)
@@ -80,21 +80,21 @@ public final class ConcurrencyExample extends ExampleBase {
                 + "In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters "
                 + "as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
         requests.add(
-            rosetteApi.createRosetteRequest(ENTITIES_SERVICE_PATH,
+            api.createRosetteRequest(ENTITIES_SERVICE_PATH,
                     DocumentRequest.<EntitiesOptions>builder().content(entitiesTextData).build(),
                     EntitiesResponse.class)
         );
         // Setting up language request
         String languageData = "Por favor Señorita, says the man.";
         requests.add(
-                rosetteApi.createRosetteRequest(LANGUAGE_SERVICE_PATH,
+                api.createRosetteRequest(LANGUAGE_SERVICE_PATH,
                         DocumentRequest.<LanguageOptions>builder().content(languageData).build(),
                         LanguageResponse.class)
         );
         // Setting up morphology request
         // No content is given to this request and it will return an error response
         requests.add(
-                rosetteApi.createRosetteRequest(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.COMPLETE,
+                api.createRosetteRequest(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.COMPLETE,
                         DocumentRequest.<MorphologyOptions>builder().build(),
                         MorphologyResponse.class)
         );
@@ -108,21 +108,21 @@ public final class ConcurrencyExample extends ExampleBase {
         }
         double threshold = 0.75;
         requests.add(
-                rosetteApi.createRosetteRequest(NAME_DEDUPLICATION_SERVICE_PATH,
+                api.createRosetteRequest(NAME_DEDUPLICATION_SERVICE_PATH,
                         NameDeduplicationRequest.builder().names(names).threshold(threshold).build(),
                         NameDeduplicationResponse.class)
         );
         //Setting up the tokens request
         String tokensData = "北京大学生物系主任办公室内部会议";
         requests.add(
-                rosetteApi.createRosetteRequest(TOKENS_SERVICE_PATH,
+                api.createRosetteRequest(TOKENS_SERVICE_PATH,
                         DocumentRequest.builder().content(tokensData).build(),
                         TokensResponse.class)
         );
         //Setting up the transliteration request
         String transliterationData = "ana r2ye7 el gam3a el sa3a 3 el 3asr";
         requests.add(
-                rosetteApi.createRosetteRequest(TRANSLITERATION_SERVICE_PATH,
+                api.createRosetteRequest(TRANSLITERATION_SERVICE_PATH,
                         DocumentRequest.builder().content(transliterationData).build(),
                         TransliterationResponse.class)
         );

--- a/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/EntitiesExample.java
@@ -39,14 +39,14 @@ public final class EntitiesExample extends ExampleBase {
 
     private void run() throws IOException {
         String entitiesTextData = "The Securities and Exchange Commission today announced the leadership of the agency’s trial unit.  Bridget Fitzpatrick has been named Chief Litigation Counsel of the SEC and David Gottesman will continue to serve as the agency’s Deputy Chief Litigation Counsel. Since December 2016, Ms. Fitzpatrick and Mr. Gottesman have served as Co-Acting Chief Litigation Counsel.  In that role, they were jointly responsible for supervising the trial unit at the agency’s Washington D.C. headquarters as well as coordinating with litigators in the SEC’s 11 regional offices around the country.";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                 .key(getApiKeyFromSystemProperty())
                                 .url(getAltUrlFromSystemProperty())
                                 .build();
         DocumentRequest<EntitiesOptions> request = DocumentRequest.<EntitiesOptions>builder()
                 .content(entitiesTextData)
                 .build();
-        EntitiesResponse response = rosetteApi.perform(ENTITIES_SERVICE_PATH, request, EntitiesResponse.class);
+        EntitiesResponse response = api.perform(ENTITIES_SERVICE_PATH, request, EntitiesResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/EventsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/EventsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/EventsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/EventsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/EventsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/EventsExample.java
@@ -38,7 +38,7 @@ public class EventsExample extends ExampleBase {
 
     private void run() throws Exception {
         String topicsData = "I am looking for flights to Super Bowl 2022 in Inglewood, LA.";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -46,7 +46,7 @@ public class EventsExample extends ExampleBase {
                 .language(LanguageCode.ENGLISH)
                 .content(topicsData)
                 .build();
-        EventsResponse resp = rosetteApi.perform(EVENTS_SERVICE_PATH, request, EventsResponse.class);
+        EventsResponse resp = api.perform(EVENTS_SERVICE_PATH, request, EventsResponse.class);
         System.out.println(responseToJson(resp));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
@@ -27,8 +27,10 @@ import com.fasterxml.jackson.databind.SerializationFeature;
  */
 @SuppressWarnings("java:S106")
 public abstract class ExampleBase {
-    private static final String KEY_PROP_NAME = "rosette.api.key";
-    private static final String URL_PROP_NAME = "rosette.api.altUrl";
+    private static final String KEY_PROP_NAME = "analytics.api.key";
+    private static final String URL_PROP_NAME = "analytics.api.altUrl";
+    private static final String LEGACY_KEY_PROP_NAME = "rosette.api.key";
+    private static final String LEGACY_URL_PROP_NAME = "rosette.api.altUrl";
     private static final String USAGE_STR = "Usage: java -cp rosette-api-examples.jar:lib/rosette-api-manifest.jar "
             + "-D" + KEY_PROP_NAME + "=<required_api_key> " + "-D" + URL_PROP_NAME + "=<optional_alternate_url> ";
 
@@ -36,8 +38,10 @@ public abstract class ExampleBase {
      * @return api key using system property {@value com.basistech.rosette.examples.ExampleBase#KEY_PROP_NAME}
      */
     protected String getApiKeyFromSystemProperty() {
-        String apiKeyStr = System.getProperty(KEY_PROP_NAME);
-        if (apiKeyStr == null || apiKeyStr.trim().length() < 1) {
+        String apiKeyStr = System.getProperty(KEY_PROP_NAME) != null
+            ? System.getProperty(KEY_PROP_NAME)
+            : System.getProperty(LEGACY_KEY_PROP_NAME);
+        if (apiKeyStr == null || apiKeyStr.trim().isEmpty()) {
             showUsage(getClass());
             System.exit(1);
         }
@@ -48,8 +52,10 @@ public abstract class ExampleBase {
      * @return alternate url using system property {@value com.basistech.rosette.examples.ExampleBase#URL_PROP_NAME}
      */
     protected String getAltUrlFromSystemProperty() {
-        String altUrlStr = System.getProperty(URL_PROP_NAME);
-        if (altUrlStr == null || altUrlStr.trim().length() < 1) {
+        String altUrlStr = System.getProperty(URL_PROP_NAME) != null
+            ? System.getProperty(URL_PROP_NAME)
+            : System.getProperty(LEGACY_URL_PROP_NAME);
+        if (altUrlStr == null || altUrlStr.trim().isEmpty()) {
             altUrlStr = "https://analytics.babelstreet.com/rest/v1";
         }
         return altUrlStr.trim();

--- a/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
@@ -66,7 +66,7 @@ public abstract class ExampleBase {
     /**
      * Converts a response to JSON string
      *
-     * @param response {@link com.basistech.rosette.apimodel.Response Response} from RosetteAPI
+     * @param response {@link com.basistech.rosette.apimodel.Response Response} from Analytics API
      * @return the json string.
      * @throws JsonProcessingException if the Jackson library throws an error serializing.
      */

--- a/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
@@ -50,7 +50,7 @@ public abstract class ExampleBase {
     protected String getAltUrlFromSystemProperty() {
         String altUrlStr = System.getProperty(URL_PROP_NAME);
         if (altUrlStr == null || altUrlStr.trim().length() < 1) {
-            altUrlStr = "https://api.rosette.com/rest/v1";
+            altUrlStr = "https://analytics.babelstreet.com/rest/v1";
         }
         return altUrlStr.trim();
     }

--- a/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/ExampleBase.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/InfoExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/InfoExample.java
@@ -35,13 +35,13 @@ public final class InfoExample extends ExampleBase {
     }
 
     private void run() throws IOException {
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                 .key(getApiKeyFromSystemProperty())
                                 .url(getAltUrlFromSystemProperty())
                                 .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
-        InfoResponse response = rosetteApi.info();
+        InfoResponse response = api.info();
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/InfoExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/InfoExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/InfoExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/InfoExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
@@ -41,7 +41,7 @@ public final class LanguageExample extends ExampleBase {
     private void run() throws IOException {
         String languageData = "Por favor Señorita, says the man.";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
@@ -50,7 +50,7 @@ public final class LanguageExample extends ExampleBase {
         DocumentRequest<LanguageOptions> request = DocumentRequest.<LanguageOptions>builder()
                                                                   .content(languageData)
                                                                   .build();
-        LanguageResponse response = rosetteApi.perform(LANGUAGE_SERVICE_PATH, request, LanguageResponse.class);
+        LanguageResponse response = api.perform(LANGUAGE_SERVICE_PATH, request, LanguageResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/LanguageExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/LanguageMultilingualExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/LanguageMultilingualExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/LanguageMultilingualExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/LanguageMultilingualExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/LanguageMultilingualExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/LanguageMultilingualExample.java
@@ -41,12 +41,12 @@ public final class LanguageMultilingualExample extends ExampleBase {
     private void run() throws IOException {
         String languageMultilingualData = "On Thursday, as protesters gathered in Washington D.C., the United States Federal Communications Commission under Chairman Ajit Pai voted 3-2 to overturn a 2015 decision, commonly called Net Neutrality, that forbade Internet service providers (ISPs) such as Verizon, Comcast, and AT&T from blocking individual websites or charging websites or customers more for faster load times.  Quatre femmes ont été nommées au Conseil de rédaction de la loi du Qatar. Jeudi, le décret royal du Qatar a annoncé que 28 nouveaux membres ont été nommés pour le Conseil de la Choura du pays.  ذكرت مصادر أمنية يونانية، أن 9 موقوفين من منظمة \"د هـ ك ب ج\" الذين كانت قد أوقفتهم الشرطة اليونانية في وقت سابق كانوا يخططون لاغتيال الرئيس التركي رجب طيب أردوغان.";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
         //The api object creates an http client, but to provide your own:
-        //rosetteApi.httpClient(CloseableHttpClient)
+        //api.httpClient(CloseableHttpClient)
 
         LanguageOptions options = LanguageOptions.builder().multilingual(true).build();
 
@@ -54,7 +54,7 @@ public final class LanguageMultilingualExample extends ExampleBase {
             .content(languageMultilingualData)
             .options(options)
             .build();
-        LanguageResponse response = rosetteApi.perform(LANGUAGE_SERVICE_PATH, request, LanguageResponse.class);
+        LanguageResponse response = api.perform(LANGUAGE_SERVICE_PATH, request, LanguageResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompleteExample.java
@@ -42,14 +42,14 @@ public final class MorphologyCompleteExample extends ExampleBase {
     private void run() throws IOException {
         String morphologyCompleteData = "The quick brown fox jumped over the lazy dog. 👍🏾 Yes he did. B)";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
         DocumentRequest<MorphologyOptions> request = DocumentRequest.<MorphologyOptions>builder().content(morphologyCompleteData).build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
-        MorphologyResponse response = rosetteApi.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.COMPLETE, request, MorphologyResponse.class);
+        MorphologyResponse response = api.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.COMPLETE, request, MorphologyResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyCompoundComponentsExample.java
@@ -42,7 +42,7 @@ public final class MorphologyCompoundComponentsExample extends ExampleBase {
 
     private void run() throws IOException {
         String morphologyCompoundComponentsData = "Rechtsschutzversicherungsgesellschaften";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
@@ -51,7 +51,7 @@ public final class MorphologyCompoundComponentsExample extends ExampleBase {
         DocumentRequest<MorphologyOptions> request = DocumentRequest.<MorphologyOptions>builder().content(morphologyCompoundComponentsData)
                 .language(LanguageCode.GERMAN) // example of specifying the language.
                 .build();
-        MorphologyResponse response = rosetteApi.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.COMPOUND_COMPONENTS,
+        MorphologyResponse response = api.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.COMPOUND_COMPONENTS,
                 request, MorphologyResponse.class);
 
         System.out.println(responseToJson(response));

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
@@ -41,13 +41,13 @@ public final class MorphologyHanReadingsExample extends ExampleBase {
 
     private void run() throws IOException {
         String morphologyHanReadingsData = "北京大学生物系主任办公室内部会议";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
         DocumentRequest<MorphologyOptions> request = DocumentRequest.<MorphologyOptions>builder().content(morphologyHanReadingsData)
                 .build();
-        MorphologyResponse response = rosetteApi.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.HAN_READINGS,
+        MorphologyResponse response = api.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.HAN_READINGS,
                 request, MorphologyResponse.class);
         System.out.println(responseToJson(response));
     }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyHanReadingsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyLemmasExample.java
@@ -41,13 +41,13 @@ public final class MorphologyLemmasExample extends ExampleBase {
 
     private void run() throws IOException {
         String morphologyLemmasData = "The fact is that the geese just went back to get a rest and I'm not banking on their return soon";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
         DocumentRequest<MorphologyOptions> request = DocumentRequest.<MorphologyOptions>builder().content(morphologyLemmasData)
                 .build();
-        MorphologyResponse response = rosetteApi.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.LEMMAS,
+        MorphologyResponse response = api.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.LEMMAS,
                 request, MorphologyResponse.class);
         System.out.println(responseToJson(response));
     }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
@@ -42,13 +42,13 @@ public final class MorphologyPartsOfSpeechExample extends ExampleBase {
     private void run() throws IOException {
         String morphologyPartsOfSpeechData = "The fact is that the geese just went back to get a rest and I'm not banking on their return soon";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
         DocumentRequest<MorphologyOptions> request = DocumentRequest.<MorphologyOptions>builder().content(morphologyPartsOfSpeechData)
                 .build();
-        MorphologyResponse response = rosetteApi.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.PARTS_OF_SPEECH,
+        MorphologyResponse response = api.perform(MORPHOLOGY_SERVICE_PATH + "/" + MorphologicalFeature.PARTS_OF_SPEECH,
                 request, MorphologyResponse.class);
         System.out.println(responseToJson(response));
     }

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/MorphologyPartsOfSpeechExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/NameDeduplicationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameDeduplicationExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/NameDeduplicationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameDeduplicationExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/NameDeduplicationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameDeduplicationExample.java
@@ -51,14 +51,14 @@ public final class NameDeduplicationExample extends ExampleBase {
         }
         double threshold = 0.75;
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
         NameDeduplicationRequest request = NameDeduplicationRequest.builder().names(names).threshold(threshold).build();
-        NameDeduplicationResponse response = rosetteApi.perform(NAME_DEDUPLICATION_SERVICE_PATH, request,
+        NameDeduplicationResponse response = api.perform(NAME_DEDUPLICATION_SERVICE_PATH, request,
                 NameDeduplicationResponse.class);
         System.out.println(responseToJson(response));
     }

--- a/examples/src/main/java/com/basistech/rosette/examples/NameMultipleTranslationsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameMultipleTranslationsExample.java
@@ -46,13 +46,13 @@ public final class NameMultipleTranslationsExample extends ExampleBase {
                 .maximumResults(10)
                 .build();
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
-        NameTranslationResponse response = rosetteApi.perform(NAME_TRANSLATION_SERVICE_PATH, request, NameTranslationResponse.class);
+        NameTranslationResponse response = api.perform(NAME_TRANSLATION_SERVICE_PATH, request, NameTranslationResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/NameSimilarityExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameSimilarityExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/NameSimilarityExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameSimilarityExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/NameSimilarityExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameSimilarityExample.java
@@ -49,14 +49,14 @@ public final class NameSimilarityExample extends ExampleBase {
                 .language(LanguageCode.ENGLISH)
                 .build();
         Name name2 = Name.builder().text(matchedNameData2).build();
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
         NameSimilarityRequest request = NameSimilarityRequest.builder().name1(name1).name2(name2).build();
-        NameSimilarityResponse response = rosetteApi.perform(NAME_SIMILARITY_SERVICE_PATH, request, NameSimilarityResponse.class);
+        NameSimilarityResponse response = api.perform(NAME_SIMILARITY_SERVICE_PATH, request, NameSimilarityResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/NameTranslationExample.java
@@ -45,13 +45,13 @@ public final class NameTranslationExample extends ExampleBase {
                 .targetLanguage(LanguageCode.ENGLISH)
                 .build();
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
-        NameTranslationResponse response = rosetteApi.perform(NAME_TRANSLATION_SERVICE_PATH, request, NameTranslationResponse.class);
+        NameTranslationResponse response = api.perform(NAME_TRANSLATION_SERVICE_PATH, request, NameTranslationResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/PingExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/PingExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/PingExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/PingExample.java
@@ -35,8 +35,8 @@ public final class PingExample extends ExampleBase {
     }
 
     private void run() throws IOException {
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder().key(getApiKeyFromSystemProperty()).url(getAltUrlFromSystemProperty()).build();
-        PingResponse response = rosetteApi.ping();
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder().key(getApiKeyFromSystemProperty()).url(getAltUrlFromSystemProperty()).build();
+        PingResponse response = api.ping();
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/PingExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/PingExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/README.md
+++ b/examples/src/main/java/com/basistech/rosette/examples/README.md
@@ -4,7 +4,7 @@ Each example file demonstrates one of the capabilities of the Analytics Platform
 Here are some methods for running the examples. Each example will also accept an optional `-Drosette.api.altUrl`
 parameter for overriding the default URL.
 
-A note on prerequisites. Rosette API only supports TLS 1.2 so ensure your toolchain also supports it.
+A note on prerequisites. Analytics API only supports TLS 1.2 so ensure your toolchain also supports it.
 
 #### Running from Local Source
 

--- a/examples/src/main/java/com/basistech/rosette/examples/README.md
+++ b/examples/src/main/java/com/basistech/rosette/examples/README.md
@@ -1,5 +1,5 @@
 ## Endpoint Examples
-Each example file demonstrates one of the capabilities of the Rosette Platform.
+Each example file demonstrates one of the capabilities of the Analytics Platform.
 
 Here are some methods for running the examples. Each example will also accept an optional `-Drosette.api.altUrl`
 parameter for overriding the default URL.

--- a/examples/src/main/java/com/basistech/rosette/examples/RecordSimilarityExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/RecordSimilarityExample.java
@@ -96,13 +96,13 @@ public class RecordSimilarityExample extends ExampleBase {
                         ).build()
                 ).build();
 
-        HttpRosetteAPI rosetteAPI = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                     .key(getApiKeyFromSystemProperty())
                                     .url(getAltUrlFromSystemProperty())
                                     .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
-        RecordSimilarityResponse response = rosetteAPI.perform(RECORD_SIMILARITY_SERVICE_PATH, request, RecordSimilarityResponse.class);
+        RecordSimilarityResponse response = api.perform(RECORD_SIMILARITY_SERVICE_PATH, request, RecordSimilarityResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
@@ -41,14 +41,14 @@ public final class RelationshipsExample extends ExampleBase {
     private void run() throws IOException {
         String relationshipsTextData = "FLIR Systems is headquartered in Oregon and produces thermal imaging, night vision, and infrared cameras and sensor systems.  According to the SEC’s order instituting a settled administrative proceeding, FLIR entered into a multi-million dollar contract to provide thermal binoculars to the Saudi government in November 2008.  Timms and Ramahi were the primary sales employees responsible for the contract, and also were involved in negotiations to sell FLIR’s security cameras to the same government officials.  At the time, Timms was the head of FLIR’s Middle East office in Dubai.";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
         DocumentRequest<RelationshipsOptions> request = DocumentRequest.<RelationshipsOptions>builder().content(relationshipsTextData).build();
-        RelationshipsResponse response = rosetteApi.perform(RELATIONSHIPS_SERVICE_PATH, request, RelationshipsResponse.class);
+        RelationshipsResponse response = api.perform(RELATIONSHIPS_SERVICE_PATH, request, RelationshipsResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/RelationshipsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SemanticVectorsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SemanticVectorsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Basis Technology Corp.
+ * Copyright 2023-2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SemanticVectorsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SemanticVectorsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Basis Technology Corp.
+ * Copyright 2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SemanticVectorsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SemanticVectorsExample.java
@@ -42,7 +42,7 @@ public final class SemanticVectorsExample extends ExampleBase {
     private void run() throws IOException {
         String semanticVectorsData = "Cambridge, Massachusetts";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -55,7 +55,7 @@ public final class SemanticVectorsExample extends ExampleBase {
                 .embeddingsMode(EmbeddingsMode.GEN_1)
                 .build())
             .build();
-        SemanticVectorsResponse response = rosetteApi.perform(SEMANTIC_VECTORS_SERVICE_PATH, request, SemanticVectorsResponse.class);
+        SemanticVectorsResponse response = api.perform(SEMANTIC_VECTORS_SERVICE_PATH, request, SemanticVectorsResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentencesExample.java
@@ -40,7 +40,7 @@ public final class SentencesExample extends ExampleBase {
     private void run() throws IOException {
         String sentencesData = "This land is your land. This land is my land, from California to the New York island; from the red wood forest to the Gulf Stream waters. This land was made for you and Me. As I was walking that ribbon of highway, I saw above me that endless skyway: I saw below me that golden valley: This land was made for you and me.";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -48,7 +48,7 @@ public final class SentencesExample extends ExampleBase {
         //api.httpClient(CloseableHttpClient)
         // When no options, use <?>.
         DocumentRequest<?> request = DocumentRequest.builder().content(sentencesData).build();
-        SentencesResponse response = rosetteApi.perform(SENTENCES_SERVICE_PATH, request, SentencesResponse.class);
+        SentencesResponse response = api.perform(SENTENCES_SERVICE_PATH, request, SentencesResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SentimentExample.java
@@ -47,7 +47,7 @@ public final class SentimentExample extends ExampleBase {
         // the temp file substitutes for an actual disk file.
         String sentimentFileData = "<html><head><title>New Ghostbusters Film</title></head><body><p>Original Ghostbuster Dan Aykroyd, who also co-wrote the 1984 Ghostbusters film, couldn’t be more pleased with the new all-female Ghostbusters cast, telling The Hollywood Reporter, “The Aykroyd family is delighted by this inheritance of the Ghostbusters torch by these most magnificent women in comedy.”</p></body></html>";
         try (InputStream inputStream = Files.newInputStream(createTempDataFile(sentimentFileData))) {
-            HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+            HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                     .key(getApiKeyFromSystemProperty())
                     .url(getAltUrlFromSystemProperty())
                     .build();
@@ -55,7 +55,7 @@ public final class SentimentExample extends ExampleBase {
             //api.httpClient(CloseableHttpClient)
             // When no options, use <?>.
             DocumentRequest<SentimentOptions> request = DocumentRequest.<SentimentOptions>builder().content(inputStream, "text/html").build();
-            SentimentResponse response = rosetteApi.perform(SENTIMENT_SERVICE_PATH, request, SentimentResponse.class);
+            SentimentResponse response = api.perform(SENTIMENT_SERVICE_PATH, request, SentimentResponse.class);
             System.out.println(responseToJson(response));
         }
 

--- a/examples/src/main/java/com/basistech/rosette/examples/SimilarTermsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SimilarTermsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Basis Technology Corp.
+ * Copyright 2023-2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SimilarTermsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SimilarTermsExample.java
@@ -45,7 +45,7 @@ public final class SimilarTermsExample extends ExampleBase {
     private void run() throws IOException {
         String similarTermsData = "spy";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -59,7 +59,7 @@ public final class SimilarTermsExample extends ExampleBase {
                         .resultLanguages(Lists.newArrayList(LanguageCode.SPANISH, LanguageCode.GERMAN, LanguageCode.JAPANESE))
                         .build())
                 .build();
-        SimilarTermsResponse response = rosetteApi.perform(SIMILAR_TERMS_SERVICE_PATH, request, SimilarTermsResponse.class);
+        SimilarTermsResponse response = api.perform(SIMILAR_TERMS_SERVICE_PATH, request, SimilarTermsResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/SimilarTermsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SimilarTermsExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Basis Technology Corp.
+ * Copyright 2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SyntaxDependenciesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SyntaxDependenciesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SyntaxDependenciesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SyntaxDependenciesExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/SyntaxDependenciesExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/SyntaxDependenciesExample.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import static com.basistech.rosette.api.common.AbstractRosetteAPI.SYNTAX_DEPENDENCIES_SERVICE_PATH;
 
 /**
- * Example which demonstrates the syntax dependencies endpoint of the Rosette api.
+ * Example which demonstrates the syntax dependencies endpoint of the Analytics api.
  */
 @SuppressWarnings({"java:S1166", "java:S2221", "java:S106"})
 public final class SyntaxDependenciesExample extends ExampleBase {
@@ -39,14 +39,14 @@ public final class SyntaxDependenciesExample extends ExampleBase {
 
     private void run() throws IOException {
         String syntaxDependenciesData = "Yoshinori Ohsumi, a Japanese cell biologist, was awarded the Nobel Prize in Physiology or Medicine on Monday.";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                                 .key(getApiKeyFromSystemProperty())
                                 .url(getAltUrlFromSystemProperty())
                                 .build();
         //The api object creates an http client, but to provide your own:
         //api.httpClient(CloseableHttpClient)
         DocumentRequest<?> request = DocumentRequest.builder().content(syntaxDependenciesData).build();
-        SyntaxDependenciesResponse response = rosetteApi.perform(SYNTAX_DEPENDENCIES_SERVICE_PATH, request, SyntaxDependenciesResponse.class);
+        SyntaxDependenciesResponse response = api.perform(SYNTAX_DEPENDENCIES_SERVICE_PATH, request, SyntaxDependenciesResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TokensExample.java
@@ -40,7 +40,7 @@ public final class TokensExample extends ExampleBase {
     private void run() throws IOException {
         String tokensData = "北京大学生物系主任办公室内部会议";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -48,7 +48,7 @@ public final class TokensExample extends ExampleBase {
         //api.httpClient(CloseableHttpClient)
         // When no options, use <?>.
         DocumentRequest<?> request = DocumentRequest.builder().content(tokensData).build();
-        TokensResponse response = rosetteApi.perform(TOKENS_SERVICE_PATH, request, TokensResponse.class);
+        TokensResponse response = api.perform(TOKENS_SERVICE_PATH, request, TokensResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/TopicsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TopicsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/TopicsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TopicsExample.java
@@ -38,7 +38,7 @@ public class TopicsExample extends ExampleBase {
 
     private void run() throws Exception {
         String topicsData = "Lily Collins is in talks to join Nicholas Hoult in Chernin Entertainment and Fox Searchlight's J.R.R. Tolkien biopic Tolkien. Anthony Boyle, known for playing Scorpius Malfoy in the British play Harry Potter and the Cursed Child, also has signed on for the film centered on the famed author. In Tolkien, Hoult will play the author of the Hobbit and Lord of the Rings book series that were later adapted into two Hollywood trilogies from Peter Jackson. Dome Karukoski is directing the project.";
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -46,7 +46,7 @@ public class TopicsExample extends ExampleBase {
                 .language(LanguageCode.ENGLISH)
                 .content(topicsData)
                 .build();
-        TopicsResponse resp = rosetteApi.perform(TOPICS_SERVICE_PATH, request, TopicsResponse.class);
+        TopicsResponse resp = api.perform(TOPICS_SERVICE_PATH, request, TopicsResponse.class);
         System.out.println(responseToJson(resp));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/TopicsExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TopicsExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/TransliterationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TransliterationExample.java
@@ -41,7 +41,7 @@ public class TransliterationExample extends ExampleBase {
     private void run() throws IOException {
         String transliterationData = "ana r2ye7 el gam3a el sa3a 3 el 3asr";
 
-        HttpRosetteAPI rosetteApi = new HttpRosetteAPI.Builder()
+        HttpRosetteAPI api = new HttpRosetteAPI.Builder()
                 .key(getApiKeyFromSystemProperty())
                 .url(getAltUrlFromSystemProperty())
                 .build();
@@ -51,7 +51,7 @@ public class TransliterationExample extends ExampleBase {
                 .content(transliterationData)
                 .language(LanguageCode.ARABIC)
                 .build();
-        TransliterationResponse response = rosetteApi.perform(TRANSLITERATION_SERVICE_PATH, request, TransliterationResponse.class);
+        TransliterationResponse response = api.perform(TRANSLITERATION_SERVICE_PATH, request, TransliterationResponse.class);
         System.out.println(responseToJson(response));
     }
 }

--- a/examples/src/main/java/com/basistech/rosette/examples/TransliterationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TransliterationExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/examples/src/main/java/com/basistech/rosette/examples/TransliterationExample.java
+++ b/examples/src/main/java/com/basistech/rosette/examples/TransliterationExample.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2022-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <artifactId>rosette-api-json</artifactId>
     <name>rosette-api-json</name>
-    <description>Rosette API JSON module</description>
+    <description>Babel Street Analytics API JSON module</description>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -23,7 +23,7 @@
     </parent>
     <artifactId>rosette-api-model</artifactId>
     <name>rosette-api-model</name>
-    <description>Rosette API data models</description>
+    <description>Babel Street Analytics API data models</description>
     <properties>
         <delombok.output.directory>${project.build.directory}/delombok</delombok.output.directory>
     </properties>

--- a/model/src/main/java/com/basistech/rosette/apimodel/AccuracyMode.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/AccuracyMode.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2014-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/AccuracyMode.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/AccuracyMode.java
@@ -19,7 +19,7 @@ package com.basistech.rosette.apimodel;
 import java.util.EnumSet;
 
 /**
- * Rosette API relationship accuracy mode
+ * Analytics API relationship accuracy mode
  */
 public enum AccuracyMode {
     PRECISION("precision"),

--- a/model/src/main/java/com/basistech/rosette/apimodel/AccuracyMode.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/AccuracyMode.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/CommonRosetteAPIException.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/CommonRosetteAPIException.java
@@ -18,7 +18,7 @@ package com.basistech.rosette.apimodel;
 import com.basistech.rosette.RosetteRuntimeException;
 
 /**
- * Exception from the Rosette API inherit from this exception.
+ * Exception from the Analytics API inherit from this exception.
  */
 public class CommonRosetteAPIException extends RosetteRuntimeException {
     private final transient ErrorResponse errorResponse;

--- a/model/src/main/java/com/basistech/rosette/apimodel/CommonRosetteAPIException.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/CommonRosetteAPIException.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016 Basis Technology Corp.
+* Copyright 2016-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/CommonRosetteAPIException.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/CommonRosetteAPIException.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2016-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/ConstantsResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/ConstantsResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/ConstantsResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/ConstantsResponse.java
@@ -31,12 +31,12 @@ import lombok.Getter;
 public class ConstantsResponse extends Response {
 
     /**
-     * @return the version of Rosette API
+     * @return the version of Analytics API
      */
     private final String version;
 
     /**
-     * @return the Rosette API build info
+     * @return the Analytics API build info
      */
     private final String build;
 

--- a/model/src/main/java/com/basistech/rosette/apimodel/ConstantsResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/ConstantsResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/DocumentRequest.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/DocumentRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Basis Technology Corp.
+ * Copyright 2017-2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/DocumentRequest.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/DocumentRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2024 Basis Technology Corp.
+ * Copyright 2024 Basis Technology Corp.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/DocumentRequest.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/DocumentRequest.java
@@ -24,7 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
 /**
- * This class represents the common information for all document processing requests to the Rosette API.
+ * This class represents the common information for all document processing requests to the Analytics API.
  * Most applications do not use this class directly; the methods of the {@code RosetteAPI} class
  * create request objects. More complex applications may create objects of
  * this class for themselves via the {@link DocumentRequest.DocumentRequestBuilder}.
@@ -38,7 +38,7 @@ import java.io.InputStream;
  *     <li>A binary file image, attached as an additional MIME part to the request.
  *     The application provides a MIME content type in {@code contentType}.</li>
  *     <li>A URL of a data to download. The application provides the URL in
- *     {@code contentUri}. Note that the Rosette API respects the content type
+ *     {@code contentUri}. Note that the Analytics API respects the content type
  *     returned by the server for downloaded data.</li>
  * </ol>
  * In this object the 'content' item is an {@link Object}; it contains a {@link String}

--- a/model/src/main/java/com/basistech/rosette/apimodel/ErrorResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/ErrorResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/ErrorResponse.java
@@ -22,7 +22,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
- * Rosette API response error data
+ * Analytics API response error data
  */
 @Data
 @EqualsAndHashCode

--- a/model/src/main/java/com/basistech/rosette/apimodel/ErrorResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/ErrorResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/InfoResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/InfoResponse.java
@@ -22,7 +22,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /**
- * Rosette API information 
+ * Analytics API information
  */
 @Getter
 @EqualsAndHashCode

--- a/model/src/main/java/com/basistech/rosette/apimodel/InfoResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/InfoResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/InfoResponse.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/InfoResponse.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/batch/BatchRequest.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/batch/BatchRequest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017 Basis Technology Corp.
+* Copyright 2017-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/batch/BatchRequest.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/batch/BatchRequest.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/batch/BatchRequest.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/batch/BatchRequest.java
@@ -39,12 +39,12 @@ public final class BatchRequest {
     private final String batchId = UUID.randomUUID().toString();
 
     /**
-     * A URL for RosetteAPI to call to inform you the completion of the batch.
+     * A URL for Analytics API to call to inform you the completion of the batch.
      * It must be accessible on the Internet and can only be http: or https:.
-     * RosetteAPI will use the GET method so optional parameters need to be
+     * Analytics API will use the GET method so optional parameters need to be
      * included as query parameters in the URL.
      *
-     * @return completionCallbackUrl a URL for RosetteAPI to call when batch completes
+     * @return completionCallbackUrl a URL for Analytics API to call when batch completes
      */
     private final String completionCallbackUrl;
 
@@ -56,8 +56,8 @@ public final class BatchRequest {
     /**
      * Specifies where the results should be stored. Only a valid AWS S3 URL
      * is supported at this time. The S3 bucket needs to have a proper policy
-     * statement to grant read/write permission to RosetteAPI within the batch
-     * processing time window. RosetteAPI's AWS account number is 625892746452.
+     * statement to grant read/write permission to Analytics API within the batch
+     * processing time window. Analytics API's AWS account number is 625892746452.
      *
      * Example policy statement:
      *

--- a/model/src/main/java/com/basistech/rosette/apimodel/package-info.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/package-info.java
@@ -16,6 +16,6 @@
 
 /**
  * The classes in this package make up the data model for simple requests
- * and responses to the Rosette API.
+ * and responses to the Analytics API.
  */
 package com.basistech.rosette.apimodel;

--- a/model/src/main/java/com/basistech/rosette/apimodel/package-info.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/package-info.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 Basis Technology Corp.
+* Copyright 2014-2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/model/src/main/java/com/basistech/rosette/apimodel/package-info.java
+++ b/model/src/main/java/com/basistech/rosette/apimodel/package-info.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014-2024 Basis Technology Corp.
+* Copyright 2024 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
         <tag>rosette-api-java-binding-1.31.101</tag>
     </scm>
-    <description>This is the Java binding for the Rosette API. The classes in here help Java applications to communicate with the Rosette API.</description>
+    <description>This is the Java binding for the Babel Street Analytics API. The classes in here help Java applications to communicate with the Analytics API.</description>
     <distributionManagement>
         <site>
             <id>site</id>

--- a/release/src/scripts/run_all_examples.sh
+++ b/release/src/scripts/run_all_examples.sh
@@ -44,6 +44,10 @@ if [ -n "$2" ]; then
 fi
 
 for example in $examples; do
-    java -Drosette.api.key=$key "$OPTS" -cp rosette-api-examples.jar:lib/* $example
+  if [ -n "$2" ]; then
+    java -Drosette.api.key=$key -Drosette.api.altUrl=$2 -cp rosette-api-examples.jar:lib/* $example
+  else
+    java -Drosette.api.key=$key -cp rosette-api-examples.jar:lib/* $example
+  fi
 done
 

--- a/release/src/scripts/run_all_examples.sh
+++ b/release/src/scripts/run_all_examples.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ $# -eq 0 ]; then
-    echo "Usage: $0 API_KEY" 1>&2
+    echo "Usage: $0 API_KEY [ALT_URL]" 1>&2
     exit 1
 fi
 

--- a/release/src/scripts/run_all_examples.sh
+++ b/release/src/scripts/run_all_examples.sh
@@ -8,27 +8,42 @@ fi
 key=$1
 
 read -d '' examples <<EOF
+com.basistech.rosette.examples.AddressSimilarityExample
 com.basistech.rosette.examples.CategoriesExample
+com.basistech.rosette.examples.ConcurrencyExample
 com.basistech.rosette.examples.EntitiesExample
-com.basistech.rosette.examples.EntitiesLinkedExample
+com.basistech.rosette.examples.EventsExample
 com.basistech.rosette.examples.InfoExample
 com.basistech.rosette.examples.LanguageExample
+com.basistech.rosette.examples.LanguageMultilingualExample
 com.basistech.rosette.examples.MorphologyCompleteExample
 com.basistech.rosette.examples.MorphologyCompoundComponentsExample
 com.basistech.rosette.examples.MorphologyHanReadingsExample
 com.basistech.rosette.examples.MorphologyLemmasExample
 com.basistech.rosette.examples.MorphologyPartsOfSpeechExample
 com.basistech.rosette.examples.NameDeduplicationExample
+com.basistech.rosette.examples.NameMultipleTranslationsExample
 com.basistech.rosette.examples.NameSimilarityExample
 com.basistech.rosette.examples.NameTranslationExample
 com.basistech.rosette.examples.PingExample
+com.basistech.rosette.examples.RecordSimilarityExample
 com.basistech.rosette.examples.RelationshipsExample
+com.basistech.rosette.examples.SemanticVectorsExample
 com.basistech.rosette.examples.SentencesExample
 com.basistech.rosette.examples.SentimentExample
+com.basistech.rosette.examples.SimilarTermsExample
+com.basistech.rosette.examples.SyntaxDependenciesExample
 com.basistech.rosette.examples.TokensExample
+com.basistech.rosette.examples.TopicsExample
+com.basistech.rosette.examples.TransliterationExample
 EOF
 
+OPTS=""
+if [ -n "$2" ]; then
+    OPTS="-Drosette.api.altUrl=$2"
+fi
+
 for example in $examples; do
-    java -Drosette.api.key=$key -cp rosette-api-examples.jar:lib/rosette-api-manifest.jar $example
+    java -Drosette.api.key=$key "$OPTS" -cp rosette-api-examples.jar:lib/* $example
 done
 


### PR DESCRIPTION
- Changed the default url to `analytics.babelstreet.com` and the default API key header to `X-BabelStreetAPI-Key`
- Updated the README to remove mentions of Rosette
- Rosette API to Analytics API in java doc comments and error messages it appeared
- Renamed `rosetteApi` variables in examples to `api`