### PR TITLE
NO-JIRA:  improve mixins failure modes

### DIFF
--- a/CI.Jenkinsfile
+++ b/CI.Jenkinsfile
@@ -1,7 +1,7 @@
 node ("docker-light") {
     def sourceDir = pwd()
     try {
-        env.JAVA_HOME = "${tool 'java21'}"
+        env.JAVA_HOME = "${tool 'java25'}"
         env.PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
         def mavenLocalRepo = "$JENKINS_HOME/maven-local-repositories/executor-$EXECUTOR_NUMBER"
         stage("Clean up") {
@@ -30,7 +30,7 @@ node ("docker-light") {
                        --pull always \
                        --volume ${sourceDir}:/source \
                        --volume /opt/maven-basis:/opt/maven-basis \
-                       eclipse-temurin:21-jdk-noble \
+                       eclipse-temurin:25-jdk-noble \
                        bash -c \"apt-get update && \
                              apt-get install -y git && \
                              pushd /source && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 node ("docker-light") {
     def SOURCEDIR = pwd()
     try {
-        env.JAVA_HOME = "${tool 'java21'}"
+        env.JAVA_HOME = "${tool 'java25'}"
         env.PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
         def mavenLocalRepo = "$JENKINS_HOME/maven-local-repositories/executor-$EXECUTOR_NUMBER"
         stage("Clean up") {

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -69,6 +69,10 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <sourcepath>../model/target/delombok;../api/src/main/java</sourcepath>
+                    <failOnError>false</failOnError>
+                    <failOnWarnings>false</failOnWarnings>
+                    <quiet>true</quiet>
+                    <doclint>none</doclint>
                     <additionalDependencies>
                         <additionalDependency>
                             <groupId>com.basistech.rosette</groupId>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2017-2024 Basis Technology Corp.
+  Copyright 2017-2026 Babel Street Rosette Ltd.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -46,6 +46,24 @@
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+            <version>${google-testing-compile.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/annotations/src/main/java/com/basistech/rosette/annotations/JacksonMixinProcessor.java
+++ b/annotations/src/main/java/com/basistech/rosette/annotations/JacksonMixinProcessor.java
@@ -1,5 +1,5 @@
 /*
-* Copyright 2022 Basis Technology Corp.
+* Copyright 2026 Basis Technology Corp.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -38,10 +38,7 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -75,7 +72,7 @@ public class JacksonMixinProcessor extends AbstractProcessor {
             String elementSimpleName = typeElement.getSimpleName().toString();
             if (typeElement.getAnnotation(Builder.class) != null) {
                 TypeSpec.Builder mixinClassBuilder = TypeSpec
-                        .classBuilder(typeElement.getSimpleName().toString() + "Mixin")
+                        .classBuilder(typeElement.getSimpleName() + "Mixin")
                         .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                         .addAnnotation(AnnotationSpec.builder(JsonTypeName.class)
                                 .addMember(VALUE, "$S", typeElement.getSimpleName())
@@ -89,7 +86,7 @@ public class JacksonMixinProcessor extends AbstractProcessor {
                                         .add("JsonInclude.Include.NON_NULL").build())
                                 .build())
                         .addType(TypeSpec
-                                .classBuilder(typeElement.getSimpleName().toString() + "MixinBuilder")
+                                .classBuilder(typeElement.getSimpleName() + "MixinBuilder")
                                 .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                                 .addAnnotation(AnnotationSpec.builder(JsonPOJOBuilder.class)
                                         .addMember("withPrefix", "$S", "")
@@ -101,13 +98,23 @@ public class JacksonMixinProcessor extends AbstractProcessor {
                             .build()
                             .writeTo(processingEnvironment.getFiler());
                     addMixinCode.put(elementQualifiedName + ".class",
-                            packageName + "." + typeElement.getSimpleName().toString() + "Mixin" + ".class");
+                            packageName + "." + typeElement.getSimpleName() + "Mixin" + ".class");
                     addMixinCode.put(elementQualifiedName + "." + elementSimpleName + "Builder.class",
-                            packageName + "." + typeElement.getSimpleName().toString()
-                                    + "Mixin." + typeElement.getSimpleName().toString() + "MixinBuilder.class");
+                            packageName + "." + typeElement.getSimpleName()
+                                    + "Mixin." + typeElement.getSimpleName() + "MixinBuilder.class");
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    processingEnvironment.getMessager().printMessage(
+                            Diagnostic.Kind.ERROR,
+                            "Failed to generate mixin: " + e.getMessage(),
+                            element
+                    );
                 }
+            } else {
+                processingEnvironment.getMessager().printMessage(
+                        Diagnostic.Kind.WARNING,
+                        "@JacksonMixin requires @Builder annotation",
+                        element
+                );
             }
         }
 
@@ -129,7 +136,10 @@ public class JacksonMixinProcessor extends AbstractProcessor {
                     .build()
                     .writeTo(processingEnvironment.getFiler());
         } catch (IOException e) {
-            e.printStackTrace();
+            processingEnvironment.getMessager().printMessage(
+                    Diagnostic.Kind.ERROR,
+                    "Failed to generate MixinUtil: " + e.getMessage()
+            );
         }
 
         return true;
@@ -137,7 +147,7 @@ public class JacksonMixinProcessor extends AbstractProcessor {
 
     @Override
     public Set<String> getSupportedAnnotationTypes() {
-        return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(JacksonMixin.class.getCanonicalName())));
+        return Set.of(JacksonMixin.class.getCanonicalName());
     }
 
     @Override

--- a/annotations/src/main/java/com/basistech/rosette/annotations/JacksonMixinProcessor.java
+++ b/annotations/src/main/java/com/basistech/rosette/annotations/JacksonMixinProcessor.java
@@ -111,7 +111,7 @@ public class JacksonMixinProcessor extends AbstractProcessor {
                 }
             } else {
                 processingEnvironment.getMessager().printMessage(
-                        Diagnostic.Kind.WARNING,
+                        Diagnostic.Kind.ERROR,
                         "@JacksonMixin requires @Builder annotation",
                         element
                 );

--- a/annotations/src/test/java/com/basistech/rosette/annotations/JacksonMixinProcessorTest.java
+++ b/annotations/src/test/java/com/basistech/rosette/annotations/JacksonMixinProcessorTest.java
@@ -29,15 +29,10 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-/**
- * Test for {@link JacksonMixinProcessor} to verify:
- * 1. Proper error messages when code generation fails (instead of printStackTrace)
- * 2. Warning messages when JacksonMixin is used without Builder
- */
 public class JacksonMixinProcessorTest {
 
     @Test
-    public void testJacksonMixinWithoutBuilderProducesWarning() {
+    public void testJacksonMixinWithoutBuilderProducesError() {
         JavaFileObject classWithoutBuilder = JavaFileObjects.forSourceString(
                 "test.ModelWithoutBuilder",
                 "package test;\n"
@@ -56,13 +51,12 @@ public class JacksonMixinProcessorTest {
                 .withProcessors(new JacksonMixinProcessor())
                 .compile(classWithoutBuilder);
 
-        // Compilation should succeed (it's a warning, not an error)
-        assertThat(compilation).succeeded();
+        assertThat(compilation).failed();
 
-        List<Diagnostic<? extends JavaFileObject>> warnings = compilation.warnings();
-        String warningMessage = warnings.get(0).getMessage(null);
-        assertTrue(warningMessage.contains("@JacksonMixin requires @Builder annotation"),
-                "Warning should state that Builder annotation is required. Actual: " + warningMessage);
+        List<Diagnostic<? extends JavaFileObject>> errors = compilation.errors();
+        String errorMessage = errors.get(0).getMessage(null);
+        assertTrue(errorMessage.contains("@JacksonMixin requires @Builder annotation"),
+                "Error should state that Builder annotation is required. Actual: " + errorMessage);
     }
 
     @Test

--- a/annotations/src/test/java/com/basistech/rosette/annotations/JacksonMixinProcessorTest.java
+++ b/annotations/src/test/java/com/basistech/rosette/annotations/JacksonMixinProcessorTest.java
@@ -1,0 +1,162 @@
+/*
+* Copyright 2026 Basis Technology Corp.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.basistech.rosette.annotations;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import java.util.List;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test for {@link JacksonMixinProcessor} to verify:
+ * 1. Proper error messages when code generation fails (instead of printStackTrace)
+ * 2. Warning messages when JacksonMixin is used without Builder
+ */
+public class JacksonMixinProcessorTest {
+
+    @Test
+    public void testJacksonMixinWithoutBuilderProducesWarning() {
+        JavaFileObject classWithoutBuilder = JavaFileObjects.forSourceString(
+                "test.ModelWithoutBuilder",
+                "package test;\n"
+                + "\n"
+                + "import com.basistech.rosette.annotations.JacksonMixin;\n"
+                + "import lombok.Value;\n"
+                + "\n"
+                + "@Value\n"
+                + "@JacksonMixin\n"
+                + "public class ModelWithoutBuilder {\n"
+                + "    String name;\n"
+                + "}\n"
+        );
+
+        Compilation compilation = Compiler.javac()
+                .withProcessors(new JacksonMixinProcessor())
+                .compile(classWithoutBuilder);
+
+        // Compilation should succeed (it's a warning, not an error)
+        assertThat(compilation).succeeded();
+
+        List<Diagnostic<? extends JavaFileObject>> warnings = compilation.warnings();
+        String warningMessage = warnings.get(0).getMessage(null);
+        assertTrue(warningMessage.contains("@JacksonMixin requires @Builder annotation"),
+                "Warning should state that Builder annotation is required. Actual: " + warningMessage);
+    }
+
+    @Test
+    public void testClassWithoutJacksonMixinHasNoWarnings() {
+        JavaFileObject normalClass = JavaFileObjects.forSourceString(
+                "test.NormalClass",
+                "package test;\n"
+                + "\n"
+                + "public class NormalClass {\n"
+                + "    String name;\n"
+                + "}\n"
+        );
+
+        Compilation compilation = Compiler.javac()
+                .withProcessors(new JacksonMixinProcessor())
+                .compile(normalClass);
+
+        assertThat(compilation).succeeded();
+
+        // Should have no warnings
+        List<Diagnostic<? extends JavaFileObject>> warnings = compilation.warnings();
+        assertEquals(0, warnings.size(),
+                "Should have no warnings for classes without JacksonMixin");
+    }
+
+
+    @Test
+    public void testJacksonMixinOnInterfaceProducesError() {
+        JavaFileObject interfaceWithAnnotation = JavaFileObjects.forSourceString(
+                "test.MyInterface",
+                "package test;\n"
+                + "\n"
+                + "import com.basistech.rosette.annotations.JacksonMixin;\n"
+                + "\n"
+                + "@JacksonMixin\n"
+                + "public interface MyInterface {\n"
+                + "    String getName();\n"
+                + "}\n"
+        );
+
+        Compilation compilation = Compiler.javac()
+                .withProcessors(new JacksonMixinProcessor())
+                .compile(interfaceWithAnnotation);
+
+        // Should fail with an error
+        assertThat(compilation).failed();
+
+        // Verify it's a meaningful error message (not a stack trace)
+        List<Diagnostic<? extends JavaFileObject>> errors = compilation.errors();
+        String errorMessage = errors.get(0).getMessage(null);
+        assertTrue(errorMessage.contains("Annotation only available to Class"),
+                "Error should state annotation is only for classes. Actual: " + errorMessage);
+    }
+
+    @Test
+    public void testJacksonMixinOnEnumProducesError() {
+        JavaFileObject enumWithAnnotation = JavaFileObjects.forSourceString(
+                "test.MyEnum",
+                "package test;\n"
+                + "\n"
+                + "import com.basistech.rosette.annotations.JacksonMixin;\n"
+                + "\n"
+                + "@JacksonMixin\n"
+                + "public enum MyEnum {\n"
+                + "    VALUE1, VALUE2\n"
+                + "}\n"
+        );
+
+        Compilation compilation = Compiler.javac()
+                .withProcessors(new JacksonMixinProcessor())
+                .compile(enumWithAnnotation);
+
+        // Should fail with an error
+        assertThat(compilation).failed();
+
+        // Verify it's a meaningful error message (not a stack trace)
+        List<Diagnostic<? extends JavaFileObject>> errors = compilation.errors();
+        String errorMessage = errors.get(0).getMessage(null);
+        assertTrue(errorMessage.contains("Annotation only available to Class"),
+                "Error should state annotation is only for classes. Actual: " + errorMessage);
+    }
+
+    @Test
+    public void testGetSupportedAnnotationTypes() {
+        JacksonMixinProcessor processor = new JacksonMixinProcessor();
+        java.util.Set<String> supportedTypes = processor.getSupportedAnnotationTypes();
+
+        // Should have exactly one supported annotation type
+        assertEquals(1, supportedTypes.size(),
+                "Should support exactly one annotation type");
+
+        // Should be the JacksonMixin annotation
+        String expectedType = JacksonMixin.class.getCanonicalName();
+        assertTrue(supportedTypes.contains(expectedType),
+                "Should support " + expectedType + " annotation. Actual: " + supportedTypes);
+    }
+}

--- a/annotations/src/test/java/com/basistech/rosette/annotations/JacksonMixinProcessorTest.java
+++ b/annotations/src/test/java/com/basistech/rosette/annotations/JacksonMixinProcessorTest.java
@@ -29,22 +29,24 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class JacksonMixinProcessorTest {
+class JacksonMixinProcessorTest {
 
     @Test
-    public void testJacksonMixinWithoutBuilderProducesError() {
+    void testJacksonMixinWithoutBuilderProducesError() {
         JavaFileObject classWithoutBuilder = JavaFileObjects.forSourceString(
                 "test.ModelWithoutBuilder",
-                "package test;\n"
-                + "\n"
-                + "import com.basistech.rosette.annotations.JacksonMixin;\n"
-                + "import lombok.Value;\n"
-                + "\n"
-                + "@Value\n"
-                + "@JacksonMixin\n"
-                + "public class ModelWithoutBuilder {\n"
-                + "    String name;\n"
-                + "}\n"
+                """
+                        package test;
+                        
+                        import com.basistech.rosette.annotations.JacksonMixin;
+                        import lombok.Value;
+                        
+                        @Value
+                        @JacksonMixin
+                        public class ModelWithoutBuilder {
+                            String name;
+                        }
+                        """
         );
 
         Compilation compilation = Compiler.javac()
@@ -60,14 +62,16 @@ public class JacksonMixinProcessorTest {
     }
 
     @Test
-    public void testClassWithoutJacksonMixinHasNoWarnings() {
+    void testClassWithoutJacksonMixinHasNoWarnings() {
         JavaFileObject normalClass = JavaFileObjects.forSourceString(
                 "test.NormalClass",
-                "package test;\n"
-                + "\n"
-                + "public class NormalClass {\n"
-                + "    String name;\n"
-                + "}\n"
+                """
+                        package test;
+                        
+                        public class NormalClass {
+                            String name;
+                        }
+                        """
         );
 
         Compilation compilation = Compiler.javac()
@@ -84,17 +88,19 @@ public class JacksonMixinProcessorTest {
 
 
     @Test
-    public void testJacksonMixinOnInterfaceProducesError() {
+    void testJacksonMixinOnInterfaceProducesError() {
         JavaFileObject interfaceWithAnnotation = JavaFileObjects.forSourceString(
                 "test.MyInterface",
-                "package test;\n"
-                + "\n"
-                + "import com.basistech.rosette.annotations.JacksonMixin;\n"
-                + "\n"
-                + "@JacksonMixin\n"
-                + "public interface MyInterface {\n"
-                + "    String getName();\n"
-                + "}\n"
+                """
+                        package test;
+                        
+                        import com.basistech.rosette.annotations.JacksonMixin;
+                        
+                        @JacksonMixin
+                        public interface MyInterface {
+                            String getName();
+                        }
+                        """
         );
 
         Compilation compilation = Compiler.javac()
@@ -112,17 +118,19 @@ public class JacksonMixinProcessorTest {
     }
 
     @Test
-    public void testJacksonMixinOnEnumProducesError() {
+    void testJacksonMixinOnEnumProducesError() {
         JavaFileObject enumWithAnnotation = JavaFileObjects.forSourceString(
                 "test.MyEnum",
-                "package test;\n"
-                + "\n"
-                + "import com.basistech.rosette.annotations.JacksonMixin;\n"
-                + "\n"
-                + "@JacksonMixin\n"
-                + "public enum MyEnum {\n"
-                + "    VALUE1, VALUE2\n"
-                + "}\n"
+                """
+                        package test;
+                        
+                        import com.basistech.rosette.annotations.JacksonMixin;
+                        
+                        @JacksonMixin
+                        public enum MyEnum {
+                            VALUE1, VALUE2
+                        }
+                        """
         );
 
         Compilation compilation = Compiler.javac()
@@ -140,7 +148,7 @@ public class JacksonMixinProcessorTest {
     }
 
     @Test
-    public void testGetSupportedAnnotationTypes() {
+    void testGetSupportedAnnotationTypes() {
         JacksonMixinProcessor processor = new JacksonMixinProcessor();
         java.util.Set<String> supportedTypes = processor.getSupportedAnnotationTypes();
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2018-2024 Basis Technology Corp.
+  Copyright 2018-2026 Babel Street Ltd.
  
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -106,6 +106,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <redirectTestOutputToFile>true</redirectTestOutputToFile>
+                </configuration>
             </plugin>
         </plugins>
         <resources>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -66,4 +66,18 @@
             <artifactId>slf4j-simple</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <failOnWarnings>false</failOnWarnings>
+                    <quiet>true</quiet>
+                    <doclint>none</doclint>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -104,6 +104,10 @@
                 </executions>
                 <configuration>
                     <sourcepath>${delombok.output.directory}</sourcepath>
+                    <failOnError>false</failOnError>
+                    <failOnWarnings>false</failOnWarnings>
+                    <quiet>true</quiet>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright 2018-2024 Basis Technology Corp.
+  Copyright 2018-2026 Babel Street Rosette Ltd.
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
     </parent>
     <packaging>pom</packaging>
     <inceptionYear>2014</inceptionYear>
-    <url>http://rosette-api.github.io/java</url>
+    <url>https://rosette-api.github.io/java/</url>
     <scm>
         <connection>scm:git:git@github.com:rosette-api/java.git</connection>
         <developerConnection>scm:git:git@github.com:rosette-api/java.git</developerConnection>
@@ -44,6 +44,7 @@
     <properties>
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
         <commons-codec.version>1.20.0</commons-codec.version>
+        <google-testing-compile.version>0.21.0</google-testing-compile.version>
         <jakarta-validation-api.version>3.1.1</jakarta-validation-api.version>
         <java-poet.version>1.13.0</java-poet.version>
         <junit.version>6.0.1</junit.version>
@@ -90,7 +91,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <compilerVersion>17</compilerVersion>
                     <source>11</source>
                     <target>11</target>
                 </configuration>


### PR DESCRIPTION
- Replace `e.printStackTrace()` with errors and helpful messages.
- Add unit tests to confirm the failure modes.
- Linting:
  - Remove unnecessary calls to `.toString()`
  - Use the simpler `Set.of(`
- Suppress Javadoc warnings in the `examples` module.
- Suppress Javadoc warnings on delomboked code.
- Remove the deprecated `compilerVersion` parameter in the compiler plugin configuration.
- Stop verbose logging test output to stdout.
- Java 25 updates for Jenkins
